### PR TITLE
Fix typo in README about the config.yml file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ manifests:
       path: path/to/manifest.json
 ```
 
-By default, `dbt-loom` will look for `dbt-loom.config.yml` in your working directory. You can also set the
+By default, `dbt-loom` will look for `dbt_loom.config.yml` in your working directory. You can also set the
 `DBT_LOOM_CONFIG_PATH` environment variable.
 
 ### Using dbt Cloud as an artifact source


### PR DESCRIPTION
A simple typo in the README it's `dbt_loom.config.yml` by default and not `dbt-loom.config.yml`.