### PR TITLE
migrated to dbt-core style logging

### DIFF
--- a/dbt_loom/__init__.py
+++ b/dbt_loom/__init__.py
@@ -10,6 +10,8 @@ import yaml
 from dbt.contracts.graph.node_args import ModelNodeArgs
 from dbt.plugins.manager import dbt_hook, dbtPlugin
 from dbt.plugins.manifest import PluginNodes
+from dbt.events.functions import fire_event
+from dbt.events.types import Note
 from networkx import DiGraph
 from pydantic import BaseModel, Field
 
@@ -286,10 +288,10 @@ class dbtLoom(dbtPlugin):
             return
 
         for manifest_reference in self.config.manifests:
-            print(
-                f"dbt-loom: Loading manifest for `{manifest_reference.name}` from "
-                f"`{manifest_reference.type.value}`"
-            )
+            fire_event(Note(
+                        msg=f"dbt-loom: Loading manifest for `{manifest_reference.name}`"
+                            f" from `{manifest_reference.type.value}`"
+                       ))
 
             manifest = self._manifest_loader.load(manifest_reference)
             if manifest is None:
@@ -303,7 +305,7 @@ class dbtLoom(dbtPlugin):
         """
         Inject PluginNodes to dbt for injection into dbt's DAG.
         """
-        print("dbt-loom: Injecting nodes")
+        fire_event(Note(msg="dbt-loom: Injecting nodes"))
         return PluginNodes(models=self.models)
 
 

--- a/dbt_loom/clients/dbt_cloud.py
+++ b/dbt_loom/clients/dbt_cloud.py
@@ -2,6 +2,8 @@ import os
 from typing import Any, Dict, Optional
 
 import requests
+from dbt.events.functions import fire_event
+from dbt.events.types import Note
 
 
 class DbtCloud:
@@ -29,7 +31,7 @@ class DbtCloud:
     def _query(self, endpoint: str, **kwargs) -> Dict:
         """Query the dbt Cloud Administrative API."""
         url = f"{self.api_endpoint}/{endpoint}"
-        print(f"Querying {url}")
+        fire_event(Note(msg=f"Querying {url}"))
         response = requests.get(
             url,
             headers={


### PR DESCRIPTION
Originally I wanted to use the dbt-core logging mechanism so that dbt-loom does not print to stdout in case the --quiet flag is speciifed for a dbt run.
In our case for some dbt macros we write the output to a file which should not contain logs from dbt.
Additonally it integrates now neatly with timestamp etc.

Resolves: #2 