### PR TITLE
Feature: Inject all upstream nodes, and enable cross-project access checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,8 +19,7 @@ logs/
 *.db
 
 reports/sources/*.csv
+
 .meltano
-
-
-
 .DS_Store
+.ruff_cache

--- a/dbt_loom/__init__.py
+++ b/dbt_loom/__init__.py
@@ -1,7 +1,7 @@
 import os
 import re
 from pathlib import Path
-from typing import Callable, Dict, Mapping, Optional
+from typing import Any, Callable, Dict, Mapping, Optional
 
 import yaml
 from dbt.contracts.graph.node_args import ModelNodeArgs
@@ -9,6 +9,8 @@ from dbt.events.functions import fire_event
 from dbt.events.types import Note
 from dbt.plugins.manager import dbt_hook, dbtPlugin
 from dbt.plugins.manifest import PluginNodes
+from dbt.config.project import VarProvider
+
 from networkx import DiGraph
 
 from dbt_loom.config import dbtLoomConfig
@@ -68,6 +70,7 @@ class LoomRunnableConfig:
     """A shim class to allow is_invalid_*_ref functions to correctly handle access for loom-injected models."""
 
     restrict_access: bool = True
+    vars: VarProvider = VarProvider(vars={})
 
 
 class dbtLoom(dbtPlugin):

--- a/dbt_loom/__init__.py
+++ b/dbt_loom/__init__.py
@@ -27,6 +27,7 @@ def identify_node_subgraph(manifest) -> Dict[str, ManifestNode]:
     return {
         unique_id: ManifestNode(**(manifest.get("nodes", {}).get(unique_id)))
         for unique_id in manifest["nodes"].keys()
+        if unique_id.split(".")[0] in ("model")
     }
 
 

--- a/test_projects/revenue/dbt_project.yml
+++ b/test_projects/revenue/dbt_project.yml
@@ -29,6 +29,8 @@ vars:
 # Configuring models
 # Full documentation: https://docs.getdbt.com/docs/configuring-models
 
+restrict-access: true
+
 # In this example config, we tell dbt to build all models in the example/ directory
 # as tables. These settings can be overridden in the individual model files
 # using the `{{ config(...) }}` macro.


### PR DESCRIPTION
# Description and Motivation
A common feature request has been to see all upstream nodes from an injected project. For some time, this has not been available for a simple technical reason: dbt-core's access checks do not fire if you are not injecting dbt Labs' undocumented `dependency` structure at runtime. The consequence of this is that all access checks would break, allowing for private models to be ref-ed outside of groups if the referrer is in a different project. Unfortunately, dbt-core is designed in a purposefully obfuscated way to prevent mere mortals for leveraging this `depenedency` argument, so extra measures were required.

To that end, I've implemented some patches that allow us to wrap the existing reference access checks with injections that allow for dependency checks to occur as expected!

With this out of the way, we now have the following features:
1. Cross-project DAGs include non-executing nodes (`ModelArgNodes`) for all upstream `Models`.
2. Cross-project `refs` that reference non-public models fail with a Parsing Error as expected.
3. I was able to remove some extra logic that was filtering down the DAG, so there will be a small performance boost.

Resolves: #40 