### PR TITLE
Fix: Update name resolution for non-model nodes to preserve cross project nodes

### DIFF
--- a/dbt_loom/manifests.py
+++ b/dbt_loom/manifests.py
@@ -4,6 +4,8 @@ from typing import Dict, List, Optional, Union
 
 from pydantic import BaseModel, Field, validator
 
+from dbt.node_types import NodeType
+
 from dbt_loom.clients.az_blob import AzureClient, AzureReferenceConfig
 from dbt_loom.clients.dbt_cloud import DbtCloud, DbtCloudReferenceConfig
 from dbt_loom.clients.gcs import GCSClient, GCSReferenceConfig
@@ -27,6 +29,7 @@ class ManifestNode(BaseModel):
     """A basic ManifestNode that can be referenced across projects."""
 
     name: str
+    resource_type: NodeType
     package_name: str
     schema_name: str = Field(alias="schema")
     database: Optional[str] = None

--- a/test_projects/revenue/models/marts/orders_v2.sql
+++ b/test_projects/revenue/models/marts/orders_v2.sql
@@ -54,6 +54,10 @@ supplies as (
 
 ),
 
+accounts as (
+    select * from {{ ref('stg_accounts') }}
+),
+
 order_items_summary as (
 
     select

--- a/test_projects/revenue/models/staging/__models.yml
+++ b/test_projects/revenue/models/staging/__models.yml
@@ -1,7 +1,6 @@
 version: 2
 
 models:
-
   - name: stg_locations
     description: List of open locations with basic cleaning and transformation applied, one row per location.
     columns:
@@ -46,6 +45,16 @@ models:
     columns:
       - name: supply_uuid
         description: The unique key of our supplies per cost.
+        tests:
+          - not_null
+          - unique
+
+  - name: stg_accounts
+    description: >
+      List of all accounts.
+    columns:
+      - name: name
+        description: The unique key of our accounts.
         tests:
           - not_null
           - unique

--- a/test_projects/revenue/models/staging/stg_accounts.sql
+++ b/test_projects/revenue/models/staging/stg_accounts.sql
@@ -1,0 +1,1 @@
+select * from {{ ref('accounts') }}

--- a/test_projects/revenue/seeds/__seeds.yml
+++ b/test_projects/revenue/seeds/__seeds.yml
@@ -4,3 +4,7 @@ seeds:
       # Manually add to config to support dbt-core 1.6.x. Note that you
       # cannot have both in latest version of 1.7.x.
       access: public
+
+  - name: accounts
+    config:
+      access: private

--- a/test_projects/revenue/seeds/accounts.csv
+++ b/test_projects/revenue/seeds/accounts.csv
@@ -1,0 +1,4 @@
+name
+foo
+bar
+baz


### PR DESCRIPTION
# Description and motivation

There is a defect in all 0.5.x versions of dbt-loom, in which the inclusion of non-model nodes (like seeds) will break project parsing in a downstream project. The root cause of this is that dbt-core hard-codes a `model` prefix to all nodes injected via `ModelArgsNode`, which is the only injectable type.

To work around this limitation, I've implemented a custom `LoomModelArgsNode` type which corrects for this hard-coded limitation.

Admittedly, I'm a little on the fence about this approach. Personally, I think that continuing to enable the inclusion of private/protected upstream models into a downstream project may have negative performance impact, and may cause user confusion if they're not aware of the project boundaries. For now, I'll preserve this inheritance, but this is something that may need to be resolved in a future minor version.

Resolves: #52 