### PR TITLE
Feature: Add a log line for the dbt-loom version

### DIFF
--- a/dbt_loom/__init__.py
+++ b/dbt_loom/__init__.py
@@ -15,6 +15,8 @@ from dbt.node_types import NodeType
 from dbt_loom.config import dbtLoomConfig
 from dbt_loom.manifests import ManifestLoader, ManifestNode
 
+import importlib.metadata
+
 
 def identify_node_subgraph(manifest) -> Dict[str, ManifestNode]:
     """
@@ -80,6 +82,11 @@ class dbtLoom(dbtPlugin):
     """
 
     def __init__(self, project_name: str):
+        # Log the version of dbt-loom being intialized
+        fire_event(
+            Note(msg=f'Initializing dbt-loom={importlib.metadata.version("dbt-loom")}')
+        )
+
         configuration_path = Path(
             os.environ.get("DBT_LOOM_CONFIG", "dbt_loom.config.yml")
         )


### PR DESCRIPTION
# Description and motivation
This PR adds a basic dbt-loom version logging line to all output. This will aid in the debugging process when users provide dbt logs.

Example output

```console
(dbt-loom-OFNZGm51-py3.11) > $ dbt build                                                                                                                            [±feature/version_logging ●●(✹)]
01:03:48  Running with dbt=1.7.14
01:03:48  Initializing dbt-loom=0.5.2
01:03:48  dbt-loom: Patching ref protection methods to support dbt-loom dependencies.
01:03:48  Registered adapter: duckdb=1.7.4
01:03:48  dbt-loom: Injecting nodes
```

Resolves: #53 