### PR TITLE
Fix: Support dbt-core 1.8.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ version_files = ["pyproject.toml:^version"]
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
-dbt-core = ">=1.6.0,<=1.8.0"
+dbt-core = ">=1.6.0,<1.9.0"
 requests = "^2.31.0"
 google-cloud-storage = "^2.13.0"
 boto3 = "^1.28.84"
@@ -25,7 +25,7 @@ types-networkx = "^3.2.1.20240313"
 ruff = "^0.3.0"
 pytest = "^7.4.0"
 isort = "^5.12.0"
-dbt-duckdb = ">=1.6.0,<=1.8.0"
+dbt-duckdb = ">=1.6.0,<1.9.0"
 duckdb = ">=0.8.0"
 pre-commit = "^3.6.0"
 mypy = "^1.8.0"


### PR DESCRIPTION
Allow any version of dbt-core 1.8 to be used.