### PR TITLE
feat: Resolve dbt-core defect in group checks for `protected` models. Re-enable `restrict-access` by default.

### DIFF
--- a/dbt_loom/shims.py
+++ b/dbt_loom/shims.py
@@ -1,0 +1,59 @@
+from typing import Mapping, Optional
+from dbt.contracts.graph.nodes import GraphMemberNode, ModelNode
+from dbt.contracts.graph.manifest import MaybeNonSource
+from dbt.artifacts.resources.types import NodeType, AccessType
+
+
+def is_invalid_protected_ref(
+    self,
+    node: GraphMemberNode,
+    target_model: MaybeNonSource,
+    dependencies: Optional[Mapping],
+) -> bool:
+    dependencies = dependencies or {}
+    if not isinstance(target_model, ModelNode):
+        return False
+
+    is_protected_ref = (
+        target_model.access == AccessType.Protected
+        # don't raise this reference error for ad hoc 'preview' queries
+        and node.resource_type != NodeType.SqlOperation
+        and node.resource_type != NodeType.RPCCall  # TODO: rm
+    )
+    target_dependency = dependencies.get(target_model.package_name)
+    restrict_package_access = (
+        target_dependency.restrict_access if target_dependency else False
+    )
+
+    return is_protected_ref and (
+        node.package_name != target_model.package_name and restrict_package_access
+    )
+
+
+def is_invalid_private_ref(
+    self,
+    node: GraphMemberNode,
+    target_model: MaybeNonSource,
+    dependencies: Optional[Mapping],
+) -> bool:
+    dependencies = dependencies or {}
+    if not isinstance(target_model, ModelNode):
+        return False
+
+    is_private_ref = (
+        target_model.access == AccessType.Private
+        # don't raise this reference error for ad hoc 'preview' queries
+        and node.resource_type != NodeType.SqlOperation
+        and node.resource_type != NodeType.RPCCall  # TODO: rm
+    )
+    target_dependency = dependencies.get(target_model.package_name)
+    restrict_package_access = (
+        target_dependency.restrict_access if target_dependency else False
+    )
+
+    return is_private_ref and (
+        # Invalid reference because the group does not match
+        (hasattr(node, "group") and node.group and node.group != target_model.group)  # type: ignore
+        # Or, invalid because these are different namespaces (project/package) and restrict-access is enforced
+        or (node.package_name != target_model.package_name and restrict_package_access)
+    )

--- a/dbt_loom/shims.py
+++ b/dbt_loom/shims.py
@@ -1,7 +1,11 @@
 from typing import Mapping, Optional
 from dbt.contracts.graph.nodes import GraphMemberNode, ModelNode
 from dbt.contracts.graph.manifest import MaybeNonSource
-from dbt.artifacts.resources.types import NodeType, AccessType
+
+try:
+    from dbt.artifacts.resources.types import NodeType, AccessType
+except ModuleNotFoundError:
+    from dbt.node_types import NodeType, AccessType  # type: ignore
 
 
 def is_invalid_protected_ref(

--- a/poetry.lock
+++ b/poetry.lock
@@ -2315,4 +2315,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0"
-content-hash = "cab26cf843b64a660a5dacc672c82f9ffd0d2a25b38400bcd7198a8f29ca6939"
+content-hash = "ab3d44d2760aa9a7390a695d62b5f6fccd6ac4f26434fa2a59757d4fc2b8a860"

--- a/poetry.lock
+++ b/poetry.lock
@@ -470,18 +470,19 @@ typing-extensions = ">=4.0,<5.0"
 
 [[package]]
 name = "dbt-common"
-version = "1.0.4"
+version = "1.7.0"
 description = "The shared common utilities that dbt-core and adapter implementations use"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "dbt_common-1.0.4-py3-none-any.whl", hash = "sha256:0862e3f020ea36f767c1c706d1ee555f883e4d25e9f312235ccb14b2f774a820"},
-    {file = "dbt_common-1.0.4.tar.gz", hash = "sha256:68f4bf0d7fc7dfd939ebd4bec4c7e11814c7a98c281f7bfdca86a86f57de40f5"},
+    {file = "dbt_common-1.7.0-py3-none-any.whl", hash = "sha256:ade7cf908492e83f890fd2c2bbb286f685dfe55a28ee1076f5485041b9acb93e"},
+    {file = "dbt_common-1.7.0.tar.gz", hash = "sha256:bf085abd6c2d871ec802f0b78a13467ca1d8be1603b165bb80caa9309d6b292d"},
 ]
 
 [package.dependencies]
 agate = ">=1.7.0,<1.10"
 colorama = ">=0.3.9,<0.5"
+deepdiff = ">=7.0,<8.0"
 isodate = ">=0.6,<0.7"
 jinja2 = ">=3.1.3,<4"
 jsonschema = ">=4.0,<5.0"
@@ -495,7 +496,7 @@ typing-extensions = ">=4.4,<5.0"
 [package.extras]
 build = ["check-wheel-contents", "twine", "wheel"]
 lint = ["black (>=23.3,<24.0)", "flake8", "flake8-docstrings", "flake8-pyproject", "mypy (>=1.3,<2.0)", "pytest (>=7.3,<8.0)", "types-jinja2 (>=2.11,<3.0)", "types-jsonschema (>=4.17,<5.0)", "types-protobuf (>=4.24,<5.0)", "types-python-dateutil (>=2.8,<3.0)", "types-pyyaml (>=6.0,<7.0)", "types-requests"]
-test = ["hypothesis (>=6.87,<7.0)", "pytest (>=7.3,<8.0)", "pytest-cov (>=4.1,<5.0)", "pytest-xdist (>=3.2,<4.0)"]
+test = ["hypothesis (>=6.87,<7.0)", "pytest (>=7.3,<8.0)", "pytest-cov (>=4.1,<5.0)", "pytest-mock", "pytest-xdist (>=3.2,<4.0)"]
 
 [[package]]
 name = "dbt-core"
@@ -597,6 +598,24 @@ pydantic = ">=1.10,<3"
 python-dateutil = ">=2.0,<3"
 pyyaml = ">=6.0,<7"
 typing-extensions = ">=4.4,<5"
+
+[[package]]
+name = "deepdiff"
+version = "7.0.1"
+description = "Deep Difference and Search of any Python object/data. Recreate objects by adding adding deltas to each other."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "deepdiff-7.0.1-py3-none-any.whl", hash = "sha256:447760081918216aa4fd4ca78a4b6a848b81307b2ea94c810255334b759e1dc3"},
+    {file = "deepdiff-7.0.1.tar.gz", hash = "sha256:260c16f052d4badbf60351b4f77e8390bee03a0b516246f6839bc813fb429ddf"},
+]
+
+[package.dependencies]
+ordered-set = ">=4.1.0,<4.2.0"
+
+[package.extras]
+cli = ["click (==8.1.7)", "pyyaml (==6.0.1)"]
+optimize = ["orjson"]
 
 [[package]]
 name = "distlib"
@@ -1437,6 +1456,20 @@ files = [
     {file = "numpy-1.26.4-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:7e50d0a0cc3189f9cb0aeb3a6a6af18c16f59f004b866cd2be1c14b36134a4a0"},
     {file = "numpy-1.26.4.tar.gz", hash = "sha256:2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010"},
 ]
+
+[[package]]
+name = "ordered-set"
+version = "4.1.0"
+description = "An OrderedSet is a custom MutableSet that remembers its order, so that every"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "ordered-set-4.1.0.tar.gz", hash = "sha256:694a8e44c87657c59292ede72891eb91d34131f6531463aab3009191c77364a8"},
+    {file = "ordered_set-4.1.0-py3-none-any.whl", hash = "sha256:046e1132c71fcf3330438a539928932caf51ddbc582496833e23de611de14562"},
+]
+
+[package.extras]
+dev = ["black", "mypy", "pytest"]
 
 [[package]]
 name = "packaging"
@@ -2282,4 +2315,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0"
-content-hash = "90736940b2c4e9a075db8789b3fcdacde6e2fc0300ac90a94117c0611aeba0c1"
+content-hash = "cab26cf843b64a660a5dacc672c82f9ffd0d2a25b38400bcd7198a8f29ca6939"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ azure-storage-blob = "^12.19.0"
 azure-identity = "^1.15.0"
 types-pyyaml = "^6.0.12.12"
 types-networkx = "^3.2.1.20240313"
-dbt-common = "^1.7.0"
 
 [tool.poetry.group.dev.dependencies]
 ruff = "^0.3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ azure-storage-blob = "^12.19.0"
 azure-identity = "^1.15.0"
 types-pyyaml = "^6.0.12.12"
 types-networkx = "^3.2.1.20240313"
+dbt-common = "^1.7.0"
 
 [tool.poetry.group.dev.dependencies]
 ruff = "^0.3.0"

--- a/test_projects/revenue/models/staging/stg_orders.sql
+++ b/test_projects/revenue/models/staging/stg_orders.sql
@@ -1,3 +1,9 @@
+{{
+    config(
+        materialized='table'
+    )
+}}
+
 with
 
 source as (

--- a/tests/test_dbt_core_execution.py
+++ b/tests/test_dbt_core_execution.py
@@ -4,11 +4,9 @@ from pathlib import Path
 import dbt
 from dbt.cli.main import dbtRunner, dbtRunnerResult
 
-from dbt.contracts.graph.nodes import ModelNode
-
 
 import dbt.exceptions
-import pytest
+
 
 starting_path = os.getcwd()
 
@@ -53,10 +51,6 @@ def test_dbt_core_runs_loom_plugin():
     ), "The child project is missing expected nodes. Check that injection still works."
 
 
-@pytest.mark.skip(
-    reason="This only applies when a project has restrict-access: true, which bugs all dbt tests "
-    "on private nodes. We can bring this back when that is not the case."
-)
 def test_dbt_loom_injects_dependencies():
     """Verify that dbt-core runs the dbt-loom plugin and that it flags access violations."""
 
@@ -79,7 +73,7 @@ def test_dbt_loom_injects_dependencies():
             """
             with
             upstream as (
-                select * from {{ ref('stg_orders') }}
+                select * from {{ ref('revenue', 'stg_orders') }}
             )
 
             select * from upstream


### PR DESCRIPTION
# Description and Motivations
Instead of waiting for dbt-core 1.9 and then needing to hope that other folks update, I'm just going to implement our own version of `is_invalid_protected_ref` and `is_invalid_private_ref`. This will allow us to work around a defect in group checks for protected models in projects with `restrict-access: true`. Additionally, I've re-enabled the default value of `restrict_access: true` so we get the appropriate protected model boundary checks between projects.

Resolves: #74 