### PR TITLE
Fix: Add resource type mismatch checks to prevent compilation errors for grandparent projects with seeds

### DIFF
--- a/dbt_loom/__init__.py
+++ b/dbt_loom/__init__.py
@@ -92,12 +92,7 @@ def convert_model_nodes_to_model_node_args(
         unique_id: LoomModelNodeArgs(
             schema=node.schema_name,
             identifier=node.identifier,
-            **(
-                # Small bit of logic to support both pydantic 2 and pydantic 1
-                node.model_dump(exclude={"schema_name", "depends_on", "node_config"})  # type: ignore
-                if hasattr(node, "model_dump")
-                else node.dict(exclude={"schema_name", "depends_on", "node_config"})
-            ),
+            **(node.dump()),
         )
         for unique_id, node in selected_nodes.items()
         if node is not None

--- a/dbt_loom/manifests.py
+++ b/dbt_loom/manifests.py
@@ -66,6 +66,7 @@ class ManifestNode(BaseModel):
         node_type = values.get("unique_id").split(".")[0]
         if v != node_type:
             return node_type
+        return v
 
     @property
     def identifier(self) -> str:
@@ -73,6 +74,14 @@ class ManifestNode(BaseModel):
             return self.name
 
         return self.relation_name.split(".")[-1].replace('"', "").replace("`", "")
+
+    def dump(self) -> Dict:
+        """Dump the ManifestNode to a Dict, with support for pydantic 1 and 2"""
+        exclude_set = {"schema_name", "depends_on", "node_config", "unique_id"}
+        if hasattr(self, "model_dump"):
+            return self.model_dump(exclude=exclude_set)  # type: ignore
+
+        return self.dict(exclude=exclude_set)
 
 
 class ManifestLoader:

--- a/tests/test_mainfest_node.py
+++ b/tests/test_mainfest_node.py
@@ -1,0 +1,23 @@
+from dbt_loom.manifests import ManifestNode
+
+
+try:
+    from dbt.artifacts.resources.types import NodeType
+except ModuleNotFoundError:
+    from dbt.node_types import NodeType  # type: ignore
+
+
+def test_rewrite_resource_types():
+    """Confirm that resource types are rewritten if they are incorrect due to previous injections."""
+
+    node = {
+        "unique_id": "seed.example.foo",
+        "name": "foo",
+        "package_name": "example",
+        "schema": "bar",
+        "resource_type": "model",
+    }
+
+    manifest_node = ManifestNode(**(node))  # type: ignore
+
+    assert manifest_node.resource_type == NodeType.Seed


### PR DESCRIPTION
# Description and motivation
A long-standing issue with dbt Core's use of `ModelArgNodes` is that dbt Core will hard-code the `resource_type` to `model` when exporting manifests with injected nodes. When these manifests are then loaded into a grandchild project with a seed in the grandparent, dbt Core will fail to find the grandparent's seeds due to the incorrect resource type.

This PR adds internal validations to detect these types of mismatches, and corrects for them! Along the way, I also added a basic unit test to confirm that the functionality does what we need it to do.

Resolves: #80 