### PR TITLE
Fix: Update `initialize` to handle situations where the project name provided in cofiguration does not match the real project name

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ upstream project's manifest files.
 
 ```yaml
 manifests:
-  - name: project_name
+  - name: project_name # This should match the project's real name
     type: file
     config:
       path: path/to/manifest.json

--- a/dbt_loom/__init__.py
+++ b/dbt_loom/__init__.py
@@ -114,7 +114,7 @@ class dbtLoom(dbtPlugin):
     """
 
     def __init__(self, project_name: str):
-        # Log the version of dbt-loom being intialized
+        # Log the version of dbt-loom being initialized
         fire_event(
             msg=f'Initializing dbt-loom={importlib.metadata.version("dbt-loom")}'
         )
@@ -240,7 +240,11 @@ class dbtLoom(dbtPlugin):
             if manifest is None:
                 continue
 
-            self.manifests[manifest_reference.name] = manifest
+            # Find the official project name from the manifest metadata and use that as the manifests key.
+            manifest_name = manifest.get("metadata", {}).get(
+                "project_name", manifest_reference.name
+            )
+            self.manifests[manifest_name] = manifest
 
             selected_nodes = identify_node_subgraph(manifest)
             self.models.update(convert_model_nodes_to_model_node_args(selected_nodes))

--- a/test_projects/customer_success/dbt_loom.config.yml
+++ b/test_projects/customer_success/dbt_loom.config.yml
@@ -1,5 +1,5 @@
 manifests:
-  - name: revenue
+  - name: potato
     type: file
     config:
       path: ../revenue/target/manifest.json


### PR DESCRIPTION
# Description and motivation
In #79, the reporter described a situation where a misnamed project name in the dbt-loom configuration resulted in a compilation error. This error occurs due to the interaction between how the `initialize` method store manifests, and how the `dependency_wrapper` injects `LoomRunnableConfigs` into the reference access checks. The `dependency_wrapper` uses the key names of the `manifests` dictionary as the search function for finding and injecting projects as dependencies. Historically, this key was being set to the `name` field provided in the dbt-loom config. So, if these two values differed, the project would not be injected as a dependency, and access checks would act as though the references were private instead of their real values.

This PR updates the `initialize` method to use the official `project_name` as provided in the manifest, instead. This way, we are using the same value for both dependency injection lookups _and_ the actual reference access checks, too. Along the way, I improved test cases, and updated the README. 

Resolves: #79 