### PR TITLE
Feature: Support loading manifests from remote locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ flowchart LR
 dbt-loom currently supports obtaining model definitions from:
 
 - Local manifest files
+- Remote manifest files via http(s)
 - dbt Cloud
 - GCS
 - S3-compatible object storage services
@@ -57,6 +58,8 @@ manifests:
   - name: project_name # This should match the project's real name
     type: file
     config:
+      # A path to your manifest. This can be either a local path, or a remote
+      # path accessible via http(s).
       path: path/to/manifest.json
 ```
 

--- a/dbt_loom/config.py
+++ b/dbt_loom/config.py
@@ -2,8 +2,9 @@ from enum import Enum
 from pathlib import Path
 import re
 from typing import List, Union
+from urllib.parse import ParseResult, urlparse
 
-from pydantic import BaseModel, AnyUrl, validator
+from pydantic import BaseModel, validator
 
 from dbt_loom.clients.az_blob import AzureReferenceConfig
 from dbt_loom.clients.dbt_cloud import DbtCloudReferenceConfig
@@ -24,7 +25,7 @@ class ManifestReferenceType(str, Enum):
 class FileReferenceConfig(BaseModel):
     """Configuration for a file reference"""
 
-    path: AnyUrl
+    path: ParseResult
 
     @validator("path", pre=True, always=True)
     def default_path(cls, v, values):
@@ -33,13 +34,13 @@ class FileReferenceConfig(BaseModel):
         absolute file path.
         """
 
-        if isinstance(v, AnyUrl):
+        if isinstance(v, ParseResult):
             return v
 
         if bool(re.match(r"^[a-zA-Z][a-zA-Z0-9+.-]*://", v)):
             return v
 
-        return "file://" + str(Path(v).absolute())
+        return urlparse("file://" + str(Path(v).absolute()))
 
 
 class ManifestReference(BaseModel):

--- a/dbt_loom/config.py
+++ b/dbt_loom/config.py
@@ -28,7 +28,7 @@ class FileReferenceConfig(BaseModel):
     path: ParseResult
 
     @validator("path", pre=True, always=True)
-    def default_path(cls, v, values):
+    def default_path(cls, v, values) -> ParseResult:
         """
         Check if the provided path is a valid URL. If not, convert it into an
         absolute file path.
@@ -38,7 +38,7 @@ class FileReferenceConfig(BaseModel):
             return v
 
         if bool(re.match(r"^[a-zA-Z][a-zA-Z0-9+.-]*://", v)):
-            return v
+            return urlparse(v)
 
         return urlparse("file://" + str(Path(v).absolute()))
 

--- a/dbt_loom/manifests.py
+++ b/dbt_loom/manifests.py
@@ -4,6 +4,7 @@ import json
 import gzip
 from pathlib import Path
 from typing import Dict, List, Optional
+from urllib.parse import urlunparse
 
 from pydantic import BaseModel, Field, validator
 import requests
@@ -145,7 +146,7 @@ class ManifestLoader:
         if not config.path.path:
             raise InvalidManifestPath()
 
-        response = requests.get(str(config.path), stream=True)
+        response = requests.get(urlunparse(config.path), stream=True)
         response.raise_for_status()  # Check for request errors
 
         # Check for compression on the file. If compressed, store it in a buffer

--- a/dbt_loom/manifests.py
+++ b/dbt_loom/manifests.py
@@ -99,7 +99,7 @@ class InvalidManifestPath(Exception):
 class ManifestLoader:
     def __init__(self):
         self.loading_functions = {
-            ManifestReferenceType.file: self.load_from_local_filesystem,
+            ManifestReferenceType.file: self.load_from_path,
             ManifestReferenceType.dbt_cloud: self.load_from_dbt_cloud,
             ManifestReferenceType.gcs: self.load_from_gcs,
             ManifestReferenceType.s3: self.load_from_s3,

--- a/dbt_loom/manifests.py
+++ b/dbt_loom/manifests.py
@@ -145,7 +145,7 @@ class ManifestLoader:
         if not config.path.path:
             raise InvalidManifestPath()
 
-        response = requests.get(config.path.path, stream=True)
+        response = requests.get(str(config.path), stream=True)
         response.raise_for_status()  # Check for request errors
 
         # Check for compression on the file. If compressed, store it in a buffer

--- a/tests/test_dbt_core_execution.py
+++ b/tests/test_dbt_core_execution.py
@@ -46,6 +46,8 @@ def test_dbt_core_runs_loom_plugin():
         "revenue.orders.v2",
     }
 
+    os.chdir(starting_path)
+
     assert set(output.result).issuperset(
         subset
     ), "The child project is missing expected nodes. Check that injection still works."
@@ -88,6 +90,8 @@ def test_dbt_loom_injects_dependencies():
 
     path.unlink()
 
+    os.chdir(starting_path)
+
     # Make sure nothing failed
     assert isinstance(output.exception, dbt.exceptions.DbtReferenceError)
 
@@ -128,6 +132,8 @@ def test_dbt_loom_injects_groups():
     output: dbtRunnerResult = runner.invoke(["build"])
 
     path.unlink()
+
+    os.chdir(starting_path)
 
     # Make sure nothing failed
     assert isinstance(output.exception, dbt.exceptions.DbtReferenceError)

--- a/tests/test_manifest_loaders.py
+++ b/tests/test_manifest_loaders.py
@@ -1,8 +1,9 @@
 import json
 from pathlib import Path
-import subprocess
+
 from typing import Dict, Generator, Tuple
-from pydantic import AnyUrl
+from urllib.parse import urlparse
+
 import pytest
 from dbt_loom.config import FileReferenceConfig
 from dbt_loom.manifests import ManifestLoader, UnknownManifestPathType
@@ -24,7 +25,7 @@ def test_load_from_local_filesystem_pass(example_file):
     path, example_content = example_file
 
     file_config = FileReferenceConfig(
-        path=AnyUrl(url="file://" + str(Path(path).absolute()))
+        path=urlparse("file://" + str(Path(path).absolute()))
     )
 
     output = ManifestLoader.load_from_local_filesystem(file_config)
@@ -50,7 +51,9 @@ def test_load_from_path_fails_invalid_scheme(example_file):
     scheme is applied.
     """
 
-    file_config = FileReferenceConfig(path=AnyUrl("ftp://example.com/example.json"))  # type: ignore
+    file_config = FileReferenceConfig(
+        path=urlparse("ftp://example.com/example.json"),
+    )  # type: ignore
 
     with pytest.raises(UnknownManifestPathType):
         ManifestLoader.load_from_path(file_config)
@@ -62,9 +65,9 @@ def test_load_from_remote_pass(example_file):
     _, example_content = example_file
 
     file_config = FileReferenceConfig(
-        path=AnyUrl(
-            url="https://s3.us-east-2.amazonaws.com/com.nicholasyager.dbt-loom/example.json"
-        )
+        path=urlparse(
+            "https://s3.us-east-2.amazonaws.com/com.nicholasyager.dbt-loom/example.json"
+        ),
     )
 
     output = ManifestLoader.load_from_http(file_config)

--- a/tests/test_manifest_loaders.py
+++ b/tests/test_manifest_loaders.py
@@ -1,49 +1,50 @@
 import json
 from pathlib import Path
 import subprocess
+from typing import Dict, Generator, Tuple
 from pydantic import AnyUrl
 import pytest
 from dbt_loom.config import FileReferenceConfig
 from dbt_loom.manifests import ManifestLoader, UnknownManifestPathType
 
 
-def test_load_from_local_filesystem_pass():
-    """Test that ManifestLoader can load a local JSON file."""
-
+@pytest.fixture
+def example_file() -> Generator[Tuple[Path, Dict], None, None]:
     example_content = {"foo": "bar"}
     path = Path("example.json")
-
     with open(path, "w") as file:
         json.dump(example_content, file)
+    yield path, example_content
+    path.unlink()
+
+
+def test_load_from_local_filesystem_pass(example_file):
+    """Test that ManifestLoader can load a local JSON file."""
+
+    path, example_content = example_file
 
     file_config = FileReferenceConfig(
         path=AnyUrl("file://" + str(Path(path).absolute()))
     )
 
     output = ManifestLoader.load_from_local_filesystem(file_config)
-    path.unlink()
 
     assert output == example_content
 
 
-def test_load_from_local_filesystem_local_path():
+def test_load_from_local_filesystem_local_path(example_file):
     """Test that ManifestLoader can load a local JSON file."""
 
-    example_content = {"foo": "bar"}
-    path = Path("example.json")
-
-    with open(path, "w") as file:
-        json.dump(example_content, file)
+    path, example_content = example_file
 
     file_config = FileReferenceConfig(path=str(path))  # type: ignore
 
     output = ManifestLoader.load_from_local_filesystem(file_config)
-    path.unlink()
 
     assert output == example_content
 
 
-def test_load_from_path_fails_invalid_scheme():
+def test_load_from_path_fails_invalid_scheme(example_file):
     """
     est that ManifestLoader will raise the appropriate exception if an invalid
     scheme is applied.
@@ -55,17 +56,14 @@ def test_load_from_path_fails_invalid_scheme():
         ManifestLoader.load_from_path(file_config)
 
 
-def test_load_from_remote_pass():
+def test_load_from_remote_pass(example_file):
     """Test that ManifestLoader can load a remote JSON file via HTTP(S)."""
 
-    example_content = {"foo": "bar"}
-    path = Path("example3.json")
+    path, example_content = example_file
+
     base_url = "http://127.0.0.1:8000"
 
-    with open(path, "w") as file:
-        json.dump(example_content, file)
-
-    file_config = FileReferenceConfig(path=AnyUrl(f"{base_url}/example3.json"))
+    file_config = FileReferenceConfig(path=AnyUrl(f"{base_url}/{path}"))
 
     # Invoke a server for hosting the test file.
     process = subprocess.Popen(["python3", "-m", "http.server", "8000"])
@@ -73,6 +71,5 @@ def test_load_from_remote_pass():
     output = ManifestLoader.load_from_http(file_config)
 
     process.terminate()
-    path.unlink()
 
     assert output == example_content

--- a/tests/test_manifest_loaders.py
+++ b/tests/test_manifest_loaders.py
@@ -59,12 +59,13 @@ def test_load_from_remote_pass():
     """Test that ManifestLoader can load a remote JSON file via HTTP(S)."""
 
     example_content = {"foo": "bar"}
-    path = Path("example.json")
+    path = Path("example3.json")
+    base_url = "http://127.0.0.1:8000"
 
     with open(path, "w") as file:
         json.dump(example_content, file)
 
-    file_config = FileReferenceConfig(path=AnyUrl("http://127.0.0.1:8000/example.json"))
+    file_config = FileReferenceConfig(path=AnyUrl(f"{base_url}/example3.json"))
 
     # Invoke a server for hosting the test file.
     process = subprocess.Popen(["python3", "-m", "http.server", "8000"])

--- a/tests/test_manifest_loaders.py
+++ b/tests/test_manifest_loaders.py
@@ -1,8 +1,10 @@
 import json
 from pathlib import Path
+import subprocess
 from pydantic import AnyUrl
+import pytest
 from dbt_loom.config import FileReferenceConfig
-from dbt_loom.manifests import ManifestLoader
+from dbt_loom.manifests import ManifestLoader, UnknownManifestPathType
 
 
 def test_load_from_local_filesystem_pass():
@@ -36,6 +38,40 @@ def test_load_from_local_filesystem_local_path():
     file_config = FileReferenceConfig(path=str(path))  # type: ignore
 
     output = ManifestLoader.load_from_local_filesystem(file_config)
+    path.unlink()
+
+    assert output == example_content
+
+
+def test_load_from_path_fails_invalid_scheme():
+    """
+    est that ManifestLoader will raise the appropriate exception if an invalid
+    scheme is applied.
+    """
+
+    file_config = FileReferenceConfig(path=AnyUrl("ftp://example.com/example.json"))  # type: ignore
+
+    with pytest.raises(UnknownManifestPathType):
+        ManifestLoader.load_from_path(file_config)
+
+
+def test_load_from_remote_pass():
+    """Test that ManifestLoader can load a remote JSON file via HTTP(S)."""
+
+    example_content = {"foo": "bar"}
+    path = Path("example.json")
+
+    with open(path, "w") as file:
+        json.dump(example_content, file)
+
+    file_config = FileReferenceConfig(path=AnyUrl("http://127.0.0.1:8000/example.json"))
+
+    # Invoke a server for hosting the test file.
+    process = subprocess.Popen(["python3", "-m", "http.server", "8000"])
+
+    output = ManifestLoader.load_from_http(file_config)
+
+    process.terminate()
     path.unlink()
 
     assert output == example_content

--- a/tests/test_manifest_loaders.py
+++ b/tests/test_manifest_loaders.py
@@ -1,0 +1,41 @@
+import json
+from pathlib import Path
+from pydantic import AnyUrl
+from dbt_loom.config import FileReferenceConfig
+from dbt_loom.manifests import ManifestLoader
+
+
+def test_load_from_local_filesystem_pass():
+    """Test that ManifestLoader can load a local JSON file."""
+
+    example_content = {"foo": "bar"}
+    path = Path("example.json")
+
+    with open(path, "w") as file:
+        json.dump(example_content, file)
+
+    file_config = FileReferenceConfig(
+        path=AnyUrl("file://" + str(Path(path).absolute()))
+    )
+
+    output = ManifestLoader.load_from_local_filesystem(file_config)
+    path.unlink()
+
+    assert output == example_content
+
+
+def test_load_from_local_filesystem_local_path():
+    """Test that ManifestLoader can load a local JSON file."""
+
+    example_content = {"foo": "bar"}
+    path = Path("example.json")
+
+    with open(path, "w") as file:
+        json.dump(example_content, file)
+
+    file_config = FileReferenceConfig(path=str(path))  # type: ignore
+
+    output = ManifestLoader.load_from_local_filesystem(file_config)
+    path.unlink()
+
+    assert output == example_content

--- a/tests/test_manifest_loaders.py
+++ b/tests/test_manifest_loaders.py
@@ -59,17 +59,14 @@ def test_load_from_path_fails_invalid_scheme(example_file):
 def test_load_from_remote_pass(example_file):
     """Test that ManifestLoader can load a remote JSON file via HTTP(S)."""
 
-    path, example_content = example_file
+    _, example_content = example_file
 
-    base_url = "http://127.0.0.1:8000"
-
-    file_config = FileReferenceConfig(path=AnyUrl(f"{base_url}/{path}"))
-
-    # Invoke a server for hosting the test file.
-    process = subprocess.Popen(["python3", "-m", "http.server", "8000"])
+    file_config = FileReferenceConfig(
+        path=AnyUrl(
+            "https://s3.us-east-2.amazonaws.com/com.nicholasyager.dbt-loom/example.json"
+        )
+    )
 
     output = ManifestLoader.load_from_http(file_config)
-
-    process.terminate()
 
     assert output == example_content

--- a/tests/test_manifest_loaders.py
+++ b/tests/test_manifest_loaders.py
@@ -5,7 +5,11 @@ from typing import Dict, Generator, Tuple
 from urllib.parse import urlparse
 
 import pytest
-from dbt_loom.config import FileReferenceConfig
+from dbt_loom.config import (
+    FileReferenceConfig,
+    ManifestReference,
+    ManifestReferenceType,
+)
 from dbt_loom.manifests import ManifestLoader, UnknownManifestPathType
 
 
@@ -73,3 +77,23 @@ def test_load_from_remote_pass(example_file):
     output = ManifestLoader.load_from_http(file_config)
 
     assert output == example_content
+
+
+def test_manifest_loader_selection(example_file):
+    """Confirm scheme parsing works for picking the manifest loader."""
+    _, example_content = example_file
+    manifest_loader = ManifestLoader()
+
+    file_config = FileReferenceConfig(
+        path=urlparse(
+            "https://s3.us-east-2.amazonaws.com/com.nicholasyager.dbt-loom/example.json"
+        ),
+    )
+
+    manifest_reference = ManifestReference(
+        name="example", type=ManifestReferenceType.file, config=file_config
+    )
+
+    manifest = manifest_loader.load(manifest_reference)
+
+    assert manifest == example_content

--- a/tests/test_manifest_loaders.py
+++ b/tests/test_manifest_loaders.py
@@ -24,7 +24,7 @@ def test_load_from_local_filesystem_pass(example_file):
     path, example_content = example_file
 
     file_config = FileReferenceConfig(
-        path=AnyUrl("file://" + str(Path(path).absolute()))
+        path=AnyUrl(url="file://" + str(Path(path).absolute()))
     )
 
     output = ManifestLoader.load_from_local_filesystem(file_config)
@@ -63,7 +63,7 @@ def test_load_from_remote_pass(example_file):
 
     file_config = FileReferenceConfig(
         path=AnyUrl(
-            "https://s3.us-east-2.amazonaws.com/com.nicholasyager.dbt-loom/example.json"
+            url="https://s3.us-east-2.amazonaws.com/com.nicholasyager.dbt-loom/example.json"
         )
     )
 


### PR DESCRIPTION
# Description and Motivation
This PR supports issue #86, enabling the use of generic URLs in addition to file paths for referencing manifest file locations. This opens the door to allowing for more flexible hosting arrangements that are not constrained by S3 or other specific service providers. 

To accomplish this, I modified the `FileReferenceConfig` type to have a `urllib` `ParsedResult` type, added a pre-validation step to convert strings to this type, and then split out `load_from_local_filesystem` to use `load_from_path`, which checks the URL scheme to decide on which scheme-specific loader to use. For now, this is only `file`-based schemes or `http(s)` schemes. In the future, the options may grow.


## To-do
- [x] Add tests
- [x] Update documentation