### PR TITLE
Feature: Update version pins to enable dbt-core 1.9 compatability. Add CI/CD tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,8 @@ jobs:
       matrix:
         python-version: [3.11]
         poetry-version: [1.4.2]
-        dbt-version: [1.6.0, 1.7.0, 1.8.0, 1.9.0]
+        adapter-version: [~=1.6.0, ~=1.7.0, ~=1.8.0, ~=1.9.0]
+        dbt-version: [~=1.6.0, ~=1.7.0, ~=1.8.0, ~=1.9.0]
 
     runs-on: ubuntu-latest
 
@@ -36,7 +37,7 @@ jobs:
 
       - name: Install dbt-core
         shell: bash
-        run: python -m poetry add dbt-duckdb dbt-core~=${{ matrix.dbt-version }} --allow-prereleases
+        run: python -m poetry add dbt-duckdb${{ matrix.adapter-version }} dbt-core${{ matrix.dbt-version }} --allow-prereleases
 
       - name: Test
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,6 @@ jobs:
       matrix:
         python-version: [3.11]
         poetry-version: [1.4.2]
-        adapter-version: [~=1.6.0, ~=1.7.0, ~=1.8.0, ~=1.9.0]
         dbt-version: [~=1.6.0, ~=1.7.0, ~=1.8.0, ~=1.9.0]
 
     runs-on: ubuntu-latest
@@ -37,7 +36,7 @@ jobs:
 
       - name: Install dbt-core
         shell: bash
-        run: python -m poetry add dbt-duckdb${{ matrix.adapter-version }} dbt-core${{ matrix.dbt-version }} --allow-prereleases
+        run: python -m poetry add dbt-duckdb${{ matrix.dbt-version }} dbt-core${{ matrix.dbt-version }} --allow-prereleases
 
       - name: Test
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         python-version: [3.11]
         poetry-version: [1.4.2]
-        dbt-version: [1.6.0, 1.7.0, 1.8.0]
+        dbt-version: [1.6.0, 1.7.0, 1.8.0, 1.9.0]
 
     runs-on: ubuntu-latest
 
@@ -36,7 +36,7 @@ jobs:
 
       - name: Install dbt-core
         shell: bash
-        run: python -m poetry add dbt-duckdb~=${{ matrix.dbt-version }}
+        run: python -m poetry add dbt-duckdb~=${{ matrix.dbt-version }} --allow-prereleases
 
       - name: Test
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,10 +38,6 @@ jobs:
         shell: bash
         run: python -m poetry add dbt-core~=${{ matrix.dbt-version }} --allow-prereleases
 
-      - name: Install dbt-adapter
-        shell: bash
-        run: python -m poetry add dbt-duckdb
-
       - name: Test
         run: |
           python -m poetry run pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         python-version: [3.11]
         poetry-version: [1.4.2]
-        dbt-version: [~=1.6.0, ~=1.7.0, ~=1.8.0, ~=1.9.0]
+        dbt-version: [1.6.0, 1.7.0, 1.8.0, 1.9.0b2]
 
     runs-on: ubuntu-latest
 
@@ -36,7 +36,11 @@ jobs:
 
       - name: Install dbt-core
         shell: bash
-        run: python -m poetry add dbt-duckdb${{ matrix.dbt-version }} dbt-core${{ matrix.dbt-version }} --allow-prereleases
+        run: python -m poetry add dbt-core~=${{ matrix.dbt-version }} --allow-prereleases
+
+      - name: Install dbt-adapter
+        shell: bash
+        run: python -m poetry add dbt-duckdb
 
       - name: Test
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Install dbt-core
         shell: bash
-        run: python -m poetry add dbt-duckdb~=${{ matrix.dbt-version }} --allow-prereleases
+        run: python -m poetry add dbt-duckdb dbt-core~=${{ matrix.dbt-version }} --allow-prereleases
 
       - name: Test
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ version_files = ["pyproject.toml:^version"]
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
-dbt-core = ">=1.6.0,<1.9.0"
+dbt-core = ">=1.6.0,<1.10.0"
 requests = "^2.31.0"
 google-cloud-storage = "^2.13.0"
 boto3 = "^1.28.84"
@@ -25,7 +25,7 @@ types-networkx = "^3.2.1.20240313"
 ruff = "^0.3.0"
 pytest = "^7.4.0"
 isort = "^5.12.0"
-dbt-duckdb = ">=1.6.0,<1.9.0"
+dbt-duckdb = ">=1.6.0,<1.10.0"
 duckdb = ">=0.8.0"
 pre-commit = "^3.6.0"
 mypy = "^1.8.0"


### PR DESCRIPTION
# Description and Motivation
It's dbt-core release season, so to prepare I've updated the dbt-core version pin to support dbt-core 1.9.x. To roll this into our existing build process, I've also added dbt-core 1.9.x into the version checks.