### PR TITLE
Feature: Block all dbt-loom related telemetry by default. Allow for an opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,6 @@ dbt-loom currently supports obtaining model definitions from:
 - S3-compatible object storage services
 - Azure Storage
 
-:warning: **dbt Core's plugin functionality is still in beta. Please note that this may break in the future as dbt Labs solidifies the dbt plugin API in future versions.**
-
 ## Getting Started
 
 To begin, install the `dbt-loom` python package.

--- a/dbt_loom/config.py
+++ b/dbt_loom/config.py
@@ -62,6 +62,7 @@ class dbtLoomConfig(BaseModel):
     """Configuration for dbt Loom"""
 
     manifests: List[ManifestReference]
+    enable_telemetry: bool = False
 
 
 class LoomConfigurationError(BaseException):

--- a/docs/advanced-configuration.md
+++ b/docs/advanced-configuration.md
@@ -1,0 +1,67 @@
+# Advanced Configuration
+
+`dbt-loom` also has a couple advanced configuration options for power users.
+
+## Using environment variables in the `dbt-loom` config
+
+You can easily incorporate your own environment variables into the config file. This allows for dynamic configuration values that can change based on the environment. To specify an environment variable in the `dbt-loom` config file, use one of the following formats:
+
+`${ENV_VAR}` or `$ENV_VAR`
+
+### Example:
+
+```yaml
+manifests:
+  - name: revenue
+    type: gcs
+    config:
+      project_id: ${GCP_PROJECT}
+      bucket_name: ${GCP_BUCKET}
+      object_name: ${MANIFEST_PATH}
+```
+
+## Exclude nested packages
+
+In some circumstances, like running `dbt-project-evaluator`, you may not want a
+given package in an upstream project to be imported into a downstream project.
+You can manually exclude downstream projects from injecting assets from packages
+by adding the package name to the downstream project's `excluded_packages` list.
+
+```yaml
+manifests:
+  - name: revenue
+    type: file
+    config:
+      path: ../revenue/target/manifest.json
+    excluded_packages:
+      # Provide the string name of the package to exclude during injection.
+      - dbt_project_evaluator
+```
+
+## Gzipped files
+
+`dbt-loom` natively supports decompressing gzipped manifest files. This is useful to reduce object storage size and to minimize loading times when reading manifests from object storage. Compressed file detection is triggered when the file path for the manifest is suffixed
+with `.gz`.
+
+```yaml
+manifests:
+  - name: revenue
+    type: s3
+    config:
+      bucket_name: example_bucket_name
+      object_name: manifest.json.gz
+```
+
+## Enabling Telemetry
+
+By default, the `dbt-loom` plugin blocks outbound telemetry that reports on
+the use of this plugin. This is a privacy-preserving measure for `dbt-loom`
+users that does not impact the function of dbt-core and does not impede
+dbt-core development in any way. If you _want_ this telemetry to be sent, you
+can re-enable this behavior by setting the `enable_telemetry` property
+in the `dbt_loom.config.yml` file.
+
+```yaml
+enable_telemetry: true
+manifests: ...
+```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -22,7 +22,7 @@ manifests:
 By default, `dbt-loom` will look for `dbt_loom.config.yml` in your working directory. You can also set the
 `DBT_LOOM_CONFIG` environment variable.
 
-### Using dbt Cloud as an artifact source
+## Using dbt Cloud as an artifact source
 
 You can use dbt-loom to fetch model definitions from dbt Cloud by setting up a `dbt-cloud` manifest in your `dbt-loom` config, and setting the `DBT_CLOUD_API_TOKEN` environment variable in your execution environment.
 
@@ -45,7 +45,7 @@ manifests:
       # which to fetch artifacts. Defaults to the last step.
 ```
 
-### Using an S3-compatible object store as an artifact source
+## Using an S3-compatible object store as an artifact source
 
 You can use dbt-loom to fetch manifest files from S3-compatible object stores
 by setting up ab `s3` manifest in your `dbt-loom` config. Please note that this
@@ -63,7 +63,7 @@ manifests:
       # The object name of your manifest file.
 ```
 
-### Using GCS as an artifact source
+## Using GCS as an artifact source
 
 You can use dbt-loom to fetch manifest files from Google Cloud Storage by setting up a `gcs` manifest in your `dbt-loom` config.
 
@@ -85,7 +85,7 @@ manifests:
       # The OAuth2 Credentials to use. If not passed, falls back to the default inferred from the environment.
 ```
 
-### Using Azure Storage as an artifact source
+## Using Azure Storage as an artifact source
 
 You can use dbt-loom to fetch manifest files from Azure Storage
 by setting up an `azure` manifest in your `dbt-loom` config. The `azure` type implements
@@ -102,36 +102,4 @@ manifests:
       account_name: <YOUR AZURE STORAGE ACCOUNT NAME> # The name of your Azure Storage account
       container_name: <YOUR AZURE STORAGE CONTAINER NAME> # The name of your Azure Storage container
       object_name: <YOUR OBJECT NAME> # The object name of your manifest file.
-```
-
-### Using environment variables
-
-You can easily incorporate your own environment variables into the config file. This allows for dynamic configuration values that can change based on the environment. To specify an environment variable in the `dbt-loom` config file, use one of the following formats:
-
-`${ENV_VAR}` or `$ENV_VAR`
-
-#### Example:
-
-```yaml
-manifests:
-  - name: revenue
-    type: gcs
-    config:
-      project_id: ${GCP_PROJECT}
-      bucket_name: ${GCP_BUCKET}
-      object_name: ${MANIFEST_PATH}
-```
-
-### Gzipped files
-
-`dbt-loom` natively supports decompressing gzipped manifest files. This is useful to reduce object storage size and to minimize loading times when reading manifests from object storage. Compressed file detection is triggered when the file path for the manifest is suffixed
-with `.gz`.
-
-```yaml
-manifests:
-  - name: revenue
-    type: s3
-    config:
-      bucket_name: example_bucket_name
-      object_name: manifest.json.gz
 ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,3 +60,4 @@ edit_uri: edit/main/docs/
 nav:
   - Home: index.md
   - Getting started: getting-started.md
+  - Advanced configuration: advanced-configuration.md

--- a/tests/test_dbt_core_execution.py
+++ b/tests/test_dbt_core_execution.py
@@ -140,3 +140,25 @@ def test_dbt_loom_injects_groups():
 
     # Make sure nothing failed
     assert isinstance(output.exception, dbt.exceptions.DbtReferenceError)
+
+
+def test_dbt_core_telemetry_blocking():
+    """Verify that dbt-loom prevents telemetry about itself from being sent."""
+    import shutil
+
+    runner = dbtRunner()
+
+    # Compile the revenue project
+
+    os.chdir(f"{starting_path}/test_projects/revenue")
+    runner.invoke(["clean"])
+    runner.invoke(["deps"])
+    shutil.rmtree("logs")
+    runner.invoke(["compile"])
+
+    # Check that no plugin events were sent. This is important to verify that
+    # telemetry blocking is working.
+    with open("logs/dbt.log") as log_file:
+        assert "plugin_get_nodes" not in log_file.read()
+
+    os.chdir(starting_path)


### PR DESCRIPTION
# Description and Motivation

Currently, `dbt-core`'s built-in telemetry reports on all dbt plugins loaded and the number of upstream models and packages injected. This type of telemetry presents a conflict of interest since dbt Labs' cloud offering is designed to be the "de facto" way to manage multi-project deployments, and they have a vested interest to identify and sell pricey enterprise contracts to `dbt-loom` users. 

In an effort to provide a layer of privacy to `dbt-loom` users, this PR patches the `dbt-core` `track` method such that all messages that reference `dbt-loom` are quietly dropped and not reported to dbt Lab's Snowplow instance. This does not impact any other function of `dbt-core` (including other telemetry!) or `dbt-loom`.

If a user _wants_ to provide this telemetry data, they can re-enable it by adding `enable_telemetry: true` to the project `dbt_loom.config.yaml` file.

Resolves: #92