### PR TITLE
Fix: Use Pathlib's built in URI converter

### DIFF
--- a/dbt_loom/config.py
+++ b/dbt_loom/config.py
@@ -40,7 +40,7 @@ class FileReferenceConfig(BaseModel):
         if bool(re.match(r"^[a-zA-Z][a-zA-Z0-9+.-]*://", v)):
             return urlparse(v)
 
-        return urlparse("file://" + str(Path(v).absolute()))
+        return urlparse(Path(v).absolute().as_uri())
 
 
 class ManifestReference(BaseModel):


### PR DESCRIPTION
# Description and Motivation

In #99, a fantastic user reporting a defect on Windows were file paths would break. The reported hotfix and the provided logging made it clear to me that there was an issue with how I was generating URIs for local files on Windows. After a little digging, I found the difference:

What we were generating:
```
file://C:\foo\bar
```

What we _should_ have been generating:
```
file:///C:/foo/bar
```

Definitely not ideal! So, instead of using my original half-baked solution, I instead did some digging. In this case, it turns out that Pathlib provides a built-in method on `Path` to return a URI (`as_uri()`). I guess it helps to actually read the library docs 🤦🏻 

In any case, this PR updates `FileReferenceConfig` parsing to use the correct method and it now returns valid URIs on Windows.

Resolves: #99 