### PR TITLE
fix: Strip leading slashes and unquote for better Windows support

### DIFF
--- a/dbt_loom/manifests.py
+++ b/dbt_loom/manifests.py
@@ -4,7 +4,7 @@ import json
 import gzip
 from pathlib import Path
 from typing import Dict, List, Optional
-from urllib.parse import urlunparse
+from urllib.parse import unquote, urlunparse
 
 from pydantic import BaseModel, Field, validator
 import requests
@@ -128,7 +128,7 @@ class ManifestLoader:
         if not config.path.path:
             raise InvalidManifestPath()
 
-        file_path = Path(config.path.path)
+        file_path = Path(unquote(config.path.path.lstrip("r")))
 
         if not file_path.exists():
             raise LoomConfigurationError(f"The path `{file_path}` does not exist.")


### PR DESCRIPTION
# Description and motivation
There exists a defect in dbt-loom 0.7.1 in which absolute URLs fail to parse on Windows. This is a combination of leading slashes generated in ParsedResults for absolute paths. This PR strips leading slashes from paths when loading from local file paths. Note that in the future we will be able to use `Path.from_uri()`, but this is strictly a feature of Python 3.13.

Resolves: #110 