### PR TITLE
Release/0.7.3

### DIFF
--- a/dbt_loom/manifests.py
+++ b/dbt_loom/manifests.py
@@ -2,6 +2,7 @@ import datetime
 from io import BytesIO
 import json
 import gzip
+import os
 from pathlib import Path
 from typing import Dict, List, Optional
 from urllib.parse import unquote, urlunparse
@@ -128,7 +129,16 @@ class ManifestLoader:
         if not config.path.path:
             raise InvalidManifestPath()
 
-        file_path = Path(unquote(config.path.path.lstrip("/")))
+        if config.path.netloc:
+            file_path = Path(f"//{config.path.netloc}{config.path.path}")
+        else:
+            file_path = Path(
+                unquote(
+                    config.path.path.lstrip("/")
+                    if os.name == "nt"
+                    else config.path.path
+                )
+            )
 
         if not file_path.exists():
             raise LoomConfigurationError(f"The path `{file_path}` does not exist.")

--- a/dbt_loom/manifests.py
+++ b/dbt_loom/manifests.py
@@ -128,7 +128,7 @@ class ManifestLoader:
         if not config.path.path:
             raise InvalidManifestPath()
 
-        file_path = Path(unquote(config.path.path.lstrip("r")))
+        file_path = Path(unquote(config.path.path.lstrip("/")))
 
         if not file_path.exists():
             raise LoomConfigurationError(f"The path `{file_path}` does not exist.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [tool.poetry]
 name = "dbt-loom"
-version = "0.7.2"
+version = "0.7.3"
 description = "A dbt-core plugin to import public nodes in multi-project deployments."
 authors = ["Nicholas Yager <yager@nicholasyager.com>"]
 readme = "README.md"
 packages = [{ include = "dbt_loom" }]
 
 [tool.commitizen]
-version = "0.7.2"
+version = "0.7.3"
 version_files = ["pyproject.toml:^version"]
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
# Description and motivation
This is a hotfix release to correct path parsing behavior on Windows. In 0.7.2, behavior was added to better parse out Windows paths. Unfortunately, this fix contained an undetected defect. This latest release, 0.7.3 corrects this single-character defect. In subsequent PRs I'll explore adding `windows-latest` runnings to the github actions that execute tests during CI/CD.

Resolves: #110 