### PR TITLE
Show a message when config file not exits

### DIFF
--- a/dbt_loom/__init__.py
+++ b/dbt_loom/__init__.py
@@ -237,7 +237,7 @@ class dbtLoom(dbtPlugin):
         """Read the dbt-loom configuration file."""
         if not path.exists():
             fire_event(
-                msg=f"dbt-loom: config file `{path}` not exists"
+                msg=f"dbt-loom: Config file `{path}` does not exist"
             )
             return None
 

--- a/dbt_loom/__init__.py
+++ b/dbt_loom/__init__.py
@@ -236,6 +236,9 @@ class dbtLoom(dbtPlugin):
     def read_config(self, path: Path) -> Optional[dbtLoomConfig]:
         """Read the dbt-loom configuration file."""
         if not path.exists():
+            fire_event(
+                msg=f"dbt-loom: config file `{path}` not exists"
+            )
             return None
 
         with open(path) as file:


### PR DESCRIPTION
Thanks for the useful plugin!

# Change
* Show a message when the config file not exists

(I made mistake a wrong file name such as "dbt_loom.config.yaml')

# How I tests
Using the example project (customer_success)

When the config file not exists (renamed from the original file name), a message is shown as below:
```
dbt ls
04:50:10  Running with dbt=1.9.4
04:50:10  Initializing dbt-loom=0.7.3
04:50:10  dbt-loom: config file `dbt_loom.config.yml` not exists
04:50:10  dbt-loom: Patching ref protection methods to support dbt-loom dependencies.
04:50:10  Registered adapter: duckdb=1.9.2
04:50:10  dbt-loom: Injecting nodes
04:50:10  Encountered an error:
```

When the config file exists, a message is not shown as below:
```
dbt ls
04:50:51  Running with dbt=1.9.4
04:50:52  Initializing dbt-loom=0.7.3
04:50:52  dbt-loom: Patching ref protection methods to support dbt-loom dependencies.
04:50:52  dbt-loom: Loading manifest for `potato` from `file`
04:50:52  Registered adapter: duckdb=1.9.2
04:50:52  dbt-loom: Injecting nodes
04:50:52  [WARNING]: Model orders.v1 has passed its deprecation date of 2024-01-01T00:00:00+09:00. This model should be disabled or removed.
04:50:52  Found 13 models, 5 data tests, 1 source, 539 macros
customer_success.marts.customers
```