### PR TITLE
fix: pydantic warnings

### DIFF
--- a/dbt_loom/manifests.py
+++ b/dbt_loom/manifests.py
@@ -36,7 +36,7 @@ class DependsOn(BaseModel):
     macros: List[str] = Field(default_factory=list)
 
 
-class ManifestNode(BaseModel):
+class ManifestNode(BaseModel, use_enum_values=True):
     """A basic ManifestNode that can be referenced across projects."""
 
     name: str


### PR DESCRIPTION
Resolves: #115 

We observed the same warnings as in #115 and tracked it down to the case where we had 3 dbt Projects where:
A -> B (Project B references models from A)
A -> C (Project C references models from A)
B -> C (Project C references models from B)

I was looking at the `type(self.resource_type)` at https://github.com/nicholasyager/dbt-loom/blob/2293034f6e95c64a5e846f01d09a35850cc8cdc7/dbt_loom/manifests.py#L88
and saw that most nodes had "<enum 'NodeType'>", except for seeds and hooks from Project A which are loaded via Project B (here the type is "<class 'str'>"). The same seeds/hooks from Project A directly have "<enum 'NodeType'>" (in our constellation these resources are loaded twice as we reference both A and B with dbt-loom)

cf. [https://stackoverflow.com/questions/65209934/pydantic-enum-field-does-not-get-converted-to-string](https://www.google.com/url?q=https://stackoverflow.com/questions/65209934/pydantic-enum-field-does-not-get-converted-to-string)