### PR TITLE
Add required option so that some manifest can be ignored

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,19 @@ manifests:
       - dbt_project_evaluator
 ```
 
+### Optional manifests
+
+If you want to allow a manifest reference to be missing (e.g. using dbt-loom for an upstream project to see dependencies), you can set `optional: true` for that manifest entry. When `optional` is true and the manifest file does not exist, dbt-loom will skip loading it without raising an error. If `optional` is false or omitted (the default), missing manifests will cause an error.
+
+```yaml
+manifests:
+  - name: revenue
+    type: file
+    config:
+      path: ../revenue/target/manifest.json
+    optional: true  # If the manifest file is missing, do not raise an error
+```
+
 ## Known Caveats
 
 Cross-project dependencies are a relatively new development, and dbt-core plugins

--- a/dbt_loom/config.py
+++ b/dbt_loom/config.py
@@ -59,6 +59,7 @@ class ManifestReference(BaseModel):
         SnowflakeReferenceConfig,
     ]
     excluded_packages: List[str] = Field(default_factory=list)
+    optional: bool = False
 
 
 class dbtLoomConfig(BaseModel):

--- a/dbt_loom/manifests.py
+++ b/dbt_loom/manifests.py
@@ -233,8 +233,13 @@ class ManifestLoader:
                 "not have a valid type."
             )
 
-        manifest = self.loading_functions[manifest_reference.type](
-            manifest_reference.config
-        )
+        try:
+            manifest = self.loading_functions[manifest_reference.type](
+                manifest_reference.config
+            )
+        except LoomConfigurationError as e:
+            if getattr(manifest_reference, "optional", False):
+                return None
+            raise
 
         return manifest

--- a/test_projects/revenue/dbt_loom.config.yml
+++ b/test_projects/revenue/dbt_loom.config.yml
@@ -1,0 +1,8 @@
+manifests:
+  - name: potato
+    type: file
+    optional: true
+    config:
+      path: ../customer_success/target/manifest.json
+    excluded_packages:
+      - dbt_project_evaluator

--- a/tests/test_manifest_loaders.py
+++ b/tests/test_manifest_loaders.py
@@ -9,6 +9,7 @@ from dbt_loom.config import (
     FileReferenceConfig,
     ManifestReference,
     ManifestReferenceType,
+    LoomConfigurationError,
 )
 from dbt_loom.manifests import ManifestLoader, UnknownManifestPathType
 
@@ -97,3 +98,35 @@ def test_manifest_loader_selection(example_file):
     manifest = manifest_loader.load(manifest_reference)
 
     assert manifest == example_content
+
+
+def test_load_from_local_filesystem_optional_missing():
+    """If the manifest file does not exist, it should not raise an error if optional=True."""
+    file_config = FileReferenceConfig(
+        path="not_exist_manifest.json"
+    )
+    manifest_reference = ManifestReference(
+        name="missing",
+        type=ManifestReferenceType.file,
+        config=file_config,
+        optional=True,
+    )
+    manifest_loader = ManifestLoader()
+    manifest = manifest_loader.load(manifest_reference)
+    assert manifest is None
+
+
+def test_load_from_local_filesystem_not_optional_missing():
+    """If the manifest file does not exist, it should raise an error if optional=False."""
+    file_config = FileReferenceConfig(
+        path="not_exist_manifest.json"
+    )
+    manifest_reference = ManifestReference(
+        name="missing",
+        type=ManifestReferenceType.file,
+        config=file_config,
+        optional=False,
+    )
+    manifest_loader = ManifestLoader()
+    with pytest.raises(LoomConfigurationError):
+        manifest_loader.load(manifest_reference)


### PR DESCRIPTION
## Overview
This PR adds a new `optional` flag to manifest references in dbt-loom configuration. When set to `true`, dbt-loom will skip loading the manifest if it doesn't exist, instead of raising an error. 

## Motivation
We use dbt-loom for *both* an upstream project and downstream projects so that an upstream project can check downstream dependencies.

In such a case, we want an upstream dbt-loom optional because the manifest.json of downstream projects in the upstream project is not necessary, and we want to mitigate the risk of upstream project failure because of downstream projects

## Changes
Added `optional: bool = False` field to `ManifestReference` class in `dbt_loom/config.py`

## Testing
Adding a dbt-loom.config.yml in the revenue project (upstream), and checked the below:

* When the manifest.json of customer_success(downstream) doesn't exist:
  * Before this PR change, the upstream dbt command (e.g. dbt ls) fails
  * After this PR change with optional false(or not set), the upstream dbt command (e.g. dbt ls) fails still
  * After this PR change with optional true, the upstream dbt command (e.g. dbt ls) succeeds
* When the manifest.json of customer_success(downstream) exists, the upstream dbt command (e.g. dbt ls) succeeds



