### PR TITLE
feat: Support Databricks Manifest Locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ dbt-loom currently supports obtaining model definitions from:
 - GCS
 - S3-compatible object storage services
 - Azure Storage
+- Snowflake stages
+- Databricks Volume, DBFS, and Workspace locations
 
 ## Getting Started
 
@@ -174,6 +176,24 @@ manifests:
     config:
       stage: stage_name # Stage name, can include Database/Schema
       stage_path: path/to/dbt/manifest.json # Path to manifest file in the stage
+```
+
+#### Using Databricks as an artifact source
+
+> [!WARNING]  
+> The `dbt-databricks` adapter or Python SDK is required to use the `databricks` manifest type
+
+You can use dbt-loom to fetch manifest files from Databricks Volumes, DBFS, and Workspace locations by setting up a `databricks`
+manifest in your `dbt-loom` config. The `databricks` type implements 
+[Client Unified Authentication](https://docs.databricks.com/aws/en/dev-tools/auth/unified-auth), supporting all environment variables
+and authentication mechanisms.
+
+```yaml
+manifests:
+  - name: project_name
+    type: databricks
+    config:
+      path: <WORKSPACE, VOLUME, OR DBFS PATH TO MANIFEST FILE>
 ```
 
 ### Using environment variables

--- a/dbt_loom/clients/dbx.py
+++ b/dbt_loom/clients/dbx.py
@@ -1,0 +1,53 @@
+import json
+import gzip
+from io import BytesIO
+from typing import Dict
+from dbt_loom.logging import fire_event
+from pydantic import BaseModel
+
+
+class DatabricksReferenceConfig(BaseModel):
+    """Configuration for a reference stored in Databricks"""
+
+    path: str
+
+
+class DatabricksClient:
+    """A client for loading manifest files from Databricks."""
+
+    def __init__(self, path: str) -> None:
+        self.path = path
+
+    def load_manifest(self) -> Dict:
+        """Load the manifest.json file from Databricks."""
+
+        # Import the Databricks SDK, which is a dependency of the dbt-databricks adapter
+        try:
+            from databricks.sdk import WorkspaceClient
+        except ImportError:
+            fire_event(msg="dbt-loom expected the Databricks SDK to be installed.")
+            raise
+
+        try:
+            # Initialize the workspace client; auth is handled via Databricks Unified Authentication model
+            w = WorkspaceClient()
+            # Retrieve the manifest file object
+            resp = w.files.download(self.path)
+        except Exception:
+            fire_event(msg="Unable to retrieve file from Databricks.")
+            raise
+
+        # Deserialize the object.
+        try:
+            if self.path.endswith('.gz'):
+                with gzip.GzipFile(fileobj=BytesIO(resp.contents.read())) as gzipfile:
+                    content = gzipfile.read().decode('utf-8')
+            else:
+                content = resp.contents.read()
+            return json.loads(content)
+        except json.decoder.JSONDecodeError:
+            fire_event(msg=f"The object `{self.path}` does not contain valid JSON.")
+            raise
+        except Exception:
+            fire_event(msg=f"Unable to read the data contained in the object `{self.path}")
+            raise

--- a/dbt_loom/config.py
+++ b/dbt_loom/config.py
@@ -11,6 +11,7 @@ from dbt_loom.clients.dbt_cloud import DbtCloudReferenceConfig
 from dbt_loom.clients.gcs import GCSReferenceConfig
 from dbt_loom.clients.s3 import S3ReferenceConfig
 from dbt_loom.clients.snowflake_stage import SnowflakeReferenceConfig
+from dbt_loom.clients.dbx import DatabricksReferenceConfig
 
 
 class ManifestReferenceType(str, Enum):
@@ -57,6 +58,7 @@ class ManifestReference(BaseModel):
         S3ReferenceConfig,
         AzureReferenceConfig,
         SnowflakeReferenceConfig,
+        DatabricksReferenceConfig,
     ]
     excluded_packages: List[str] = Field(default_factory=list)
     optional: bool = False

--- a/dbt_loom/manifests.py
+++ b/dbt_loom/manifests.py
@@ -21,6 +21,7 @@ from dbt_loom.clients.az_blob import AzureClient, AzureReferenceConfig
 from dbt_loom.clients.dbt_cloud import DbtCloud, DbtCloudReferenceConfig
 from dbt_loom.clients.gcs import GCSClient, GCSReferenceConfig
 from dbt_loom.clients.s3 import S3Client, S3ReferenceConfig
+from dbt_loom.clients.dbx import DatabricksClient, DatabricksReferenceConfig
 from dbt_loom.config import (
     FileReferenceConfig,
     LoomConfigurationError,
@@ -108,6 +109,7 @@ class ManifestLoader:
             ManifestReferenceType.s3: self.load_from_s3,
             ManifestReferenceType.azure: self.load_from_azure,
             ManifestReferenceType.snowflake: self.load_from_snowflake,
+            ManifestReferenceType.databricks: self.load_from_databricks
         }
 
     @staticmethod
@@ -223,6 +225,11 @@ class ManifestLoader:
         )
 
         return snowflake_client.load_manifest()
+
+    @staticmethod
+    def load_from_databricks(config: DatabricksReferenceConfig) -> Dict:
+        """Load a manifest dictionary from Databricks."""
+        databricks_client = DatabricksClient(path=config.path)
 
     def load(self, manifest_reference: ManifestReference) -> Dict:
         """Load a manifest dictionary based on a ManifestReference input."""

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -117,3 +117,21 @@ manifests:
       stage: stage_name # Stage name, can include Database/Schema
       stage_path: path/to/dbt/manifest.json # Path to manifest file in the stage
 ```
+
+## Using Databricks as an artifact source
+
+> [!WARNING]  
+> The `dbt-databricks` adapter or Python SDK is required to use the `databricks` manifest type
+
+You can use dbt-loom to fetch manifest files from Databricks Volumes, DBFS, and Workspace locations by setting up a `databricks`
+manifest in your `dbt-loom` config. The `databricks` type implements 
+[Client Unified Authentication](https://docs.databricks.com/aws/en/dev-tools/auth/unified-auth), supporting all environment variables
+and authentication mechanisms.
+
+```yaml
+manifests:
+  - name: project_name
+    type: databricks
+    config:
+      path: <WORKSPACE, VOLUME, OR DBFS PATH TO MANIFEST FILE>
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,8 @@ dbt-loom currently supports obtaining model definitions from:
 - GCS
 - S3-compatible object storage services
 - Azure Storage
+- Snowflake stages
+- Databricks Volume, DBFS, and Workspace locations
 
 ## How does it work?
 


### PR DESCRIPTION
Adds support for fetching manifest files from Databricks locations such as DBFS, Workspace, or Volumes using the Databricks SDK. The Databricks SDK is a dependency of `dbt-databricks` so I have not added it as an explicit `dbt-loom` dependency to spare non-Databricks users from having to install unnecessary packages.