### PR TITLE
Feature: Use dynamic imports for manifest clients

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         python-version: [3.11]
         poetry-version: [1.4.2]
-        dbt-version: [1.6.0, 1.7.0, 1.8.0, 1.9.0b2, 1.10.1]
+        dbt-version: [1.8.0, 1.9.0, 1.10.0]
 
     runs-on: ubuntu-latest
 

--- a/dbt_loom/clients/paradime.py
+++ b/dbt_loom/clients/paradime.py
@@ -1,8 +1,9 @@
 import os
 from typing import Dict, Optional
 
-from paradime import Paradime
 from pydantic import BaseModel
+
+from dbt_loom.logging import fire_event
 
 
 class ParadimeReferenceConfig(BaseModel):
@@ -53,6 +54,12 @@ class ParadimeClient:
 
     def load_manifest(self) -> Dict:
         """Load the manifest.json for the latest run of the schedule."""
+
+        try:
+            from paradime import Paradime
+        except ImportError:
+            fire_event(msg="dbt-loom expected paradime-io to be installed.")
+            raise
 
         paradime_client = Paradime(
             api_key=self.api_key,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ version_files = ["pyproject.toml:^version"]
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
-dbt-core = ">=1.6.0,<=1.10.1"
+dbt-core = ">=1.6.0,<=1.11.0"
 requests = "^2.31.0"
 google-cloud-storage = "^2.13.0"
 boto3 = "^1.28.84"


### PR DESCRIPTION
# Description

A large amount of the processing time that `dbt-loom` consumes is spent importing client libraries for the different manifest sources. This PR moves all of these imports into the client's `load_manifest` method (or equivalent) to defer when the import occurs. This allows us to skip all the imports that do not relate to the actual manifest sources in use by the client. In some tests, we saw as much as a 27% decrease in import overhead as a result of this change.


Resolves: #133