### PR TITLE
Release: 0.9.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [tool.poetry]
 name = "dbt-loom"
-version = "0.8.0"
+version = "0.9.0"
 description = "A dbt-core plugin to import public nodes in multi-project deployments."
 authors = ["Nicholas Yager <yager@nicholasyager.com>"]
 readme = "README.md"
 packages = [{ include = "dbt_loom" }]
 
 [tool.commitizen]
-version = "0.8.0"
+version = "0.9.0"
 version_files = ["pyproject.toml:^version"]
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
This branch bumps the dbt-loom version from 0.8.0 to 0.9.0 as part of a nice minor enhancement.