### PR TITLE
fix: Resolve manifest loading error for Databricks paths

### DIFF
--- a/dbt_loom/clients/dbx.py
+++ b/dbt_loom/clients/dbx.py
@@ -64,6 +64,12 @@ class DatabricksClient:
                     downloaded_bytes = base64.b64decode(export_content)
                 except Exception:
                     downloaded_bytes = export_content if isinstance(export_content, bytes) else export_content.encode('utf-8')
+            # If it's a DBFS path, use w.dbfs.download
+            elif path_str.startswith("/dbfs/"):
+                # Remove the /dbfs prefix for w.dbfs.download as it expects paths relative to DBFS root
+                path_str = path_str[5:]
+                resp = w.dbfs.download(path_str)
+                downloaded_bytes = resp.read()
             # For other paths (e.g., Unity Catalog volumes or external locations), use files.download.
             else:
                 resp = w.files.download(path_str)


### PR DESCRIPTION
### Issue
- #140  

### Overview
This pull request improves the manifest file loading process in Databricks environments, addressing errors when reading files from various path formats, including Databricks Workspace paths, Unity Catalog Volumes/external locations, and DBFS paths.

### Changes

1.  **Added `_get_path_str` method:**
    *   Introduced a new helper method to consistently convert the `self.path` attribute into a string format, depending on whether it's a string (`str`) or a `ParseResult` object. This also ensures proper handling of URL-encoded paths.

2.  **Improved path handling logic in `load_manifest` method:**
    *   Modified the logic to use different APIs for various Databricks path types.
    *   For Databricks Workspace paths (e.g., `/Workspace/Users/...`), `workspace.export()` is now used, and a base64 decoding step has been added to handle potentially encoded content.
    *   For DBFS paths (e.g., `/dbfs/`), `w.dbfs.download()` is utilized after removing the `/dbfs/` prefix, as it expects paths relative to the DBFS root.
    *   For other generic paths (e.g., Unity Catalog volumes or external locations), `files.download()` continues to be used.
    *   The file deserialization logic has also been adjusted to align with the new download process.

3.  **Added and improved comments:**
    *   Detailed comments have been added to key logic blocks, including the new DBFS path handling, to enhance code readability and understanding.

### Impact and Benefits
*   More robust loading of manifest files from various Databricks file storage types, including DBFS.
*   Resolution of manifest loading errors for specific path formats.
*   Improved code clarity and future maintainability.