### PR TITLE
add support for service_account_impersonation

### DIFF
--- a/dbt_loom/clients/gcs.py
+++ b/dbt_loom/clients/gcs.py
@@ -16,6 +16,7 @@ class GCSReferenceConfig(BaseModel):
     bucket_name: str
     object_name: str
     credentials: Optional[Path] = None
+    impersonate_service_account: Optional[str] = None
 
 
 class GCSClient:
@@ -27,11 +28,13 @@ class GCSClient:
         bucket_name: str,
         object_name: str,
         credentials: Optional[Path] = None,
+        impersonate_service_account: Optional[str] = None
     ) -> None:
         self.project_id = project_id
         self.bucket_name = bucket_name
         self.object_name = object_name
         self.credentials = credentials
+        self.impersonate_service_account = impersonate_service_account
 
     def load_manifest(self) -> Dict:
         """Load a manifest json from a GCS bucket."""
@@ -42,13 +45,41 @@ class GCSClient:
             fire_event(msg="dbt-loom expected google-cloud-storage to be installed.")
             raise
 
-        client = (
-            storage.Client.from_service_account_json(
-                self.credentials, project=self.project_id
+        if self.impersonate_service_account:
+            try:
+                import google.auth
+            except ImportError:
+                fire_event(
+                    msg="dbt-loom expected google-auth to be installed for service account impersonation."
+                )
+                raise
+            source_credentials, _ = google.auth.default() if self.credentials is None else google.auth.load_credentials_from_file(self.credentials)
+            impersonated_credentials = google.auth.impersonated_credentials.Credentials(
+                source_credentials=source_credentials,
+                target_principal=self.impersonate_service_account,
+                target_scopes=["https://www.googleapis.com/auth/devstorage.read_only"],
+                lifetime=60
             )
-            if self.credentials
-            else storage.Client(project=self.project_id)
-        )
+            fire_event(msg=f"Impersonating service account '{self.impersonate_service_account}' for GCS access.")
+            client = storage.Client(
+                project=self.project_id,
+                credentials=impersonated_credentials
+            )
+        else:
+            try:
+                client = (
+                    storage.Client.from_service_account_json(
+                        self.credentials, project=self.project_id
+                    )
+                    if self.credentials
+                    else storage.Client(project=self.project_id)
+                )
+            except FileNotFoundError:
+                fire_event(
+                    msg=f"The credentials file '{self.credentials}' was not found. attempting to use default application credentials."
+                )
+                client = storage.Client(project=self.project_id)
+
         bucket = client.get_bucket(self.bucket_name)
         blob = bucket.get_blob(self.object_name)
         if not blob:

--- a/dbt_loom/manifests.py
+++ b/dbt_loom/manifests.py
@@ -194,6 +194,7 @@ class ManifestLoader:
             bucket_name=config.bucket_name,
             object_name=config.object_name,
             credentials=config.credentials,
+            impersonate_service_account=config.impersonate_service_account,
         )
 
         return gcs_client.load_manifest()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "types-pyyaml>=6.0.12.12,<7",
     "types-networkx>=3.2.1.20240313,<4",
     "paradime-io>=4.11.0,<5",
+    "google-auth>=2.40.3",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -521,6 +521,7 @@ dependencies = [
     { name = "azure-storage-blob" },
     { name = "boto3" },
     { name = "dbt-core" },
+    { name = "google-auth" },
     { name = "google-cloud-storage" },
     { name = "paradime-io" },
     { name = "requests" },
@@ -528,7 +529,7 @@ dependencies = [
     { name = "types-pyyaml" },
 ]
 
-[package.dependency-groups]
+[package.dev-dependencies]
 dev = [
     { name = "dbt-duckdb" },
     { name = "duckdb" },
@@ -549,6 +550,7 @@ requires-dist = [
     { name = "azure-storage-blob", specifier = ">=12.19.0,<13" },
     { name = "boto3", specifier = ">=1.28.84,<2" },
     { name = "dbt-core", specifier = ">=1.6.0,<1.11.0" },
+    { name = "google-auth", specifier = ">=2.40.3" },
     { name = "google-cloud-storage", specifier = ">=2.13.0,<3" },
     { name = "paradime-io", specifier = ">=4.11.0,<5" },
     { name = "requests", specifier = ">=2.31.0,<3" },
@@ -556,7 +558,7 @@ requires-dist = [
     { name = "types-pyyaml", specifier = ">=6.0.12.12,<7" },
 ]
 
-[package.metadata.dependency-groups]
+[package.metadata.requires-dev]
 dev = [
     { name = "dbt-duckdb", specifier = ">=1.6.0,<1.10.0" },
     { name = "duckdb", specifier = ">=0.8.0" },


### PR DESCRIPTION
dbt supports [service-account-impersonation](https://docs.getdbt.com/docs/core/connect-data-platform/bigquery-setup#service-account-impersonation), and so should dbt-loom.
tested specifically for adc. have not tested credentials.json.

also added a minimal retry step on top of original implementation of client, that may perhaps cover https://github.com/nicholasyager/dbt-loom/pull/147
can revert that if not.