### PR TITLE
feat: Update CI/CD tests to confirm dbt-core 1.11 functionality.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.11]
-        dbt-version: [1.8.0, 1.9.0, 1.10.0]
+        python-version: [3.12]
+        dbt-version: [1.9.0, 1.10.0, 1.11.0]
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
I'm also going to remove 1.8 since it's well outside the EOL period.