### PR TITLE
✨ Improve docs for injected nodes

### DIFF
--- a/dbt_loom/__init__.py
+++ b/dbt_loom/__init__.py
@@ -1,9 +1,15 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import os
 import re
 from pathlib import Path
-from typing import Callable, Dict, Optional, Set
+from typing import TYPE_CHECKING, Callable, Dict, Optional, Set
 
+try:
+    from dbt.artifacts.resources.v1.components import ColumnInfo
+except ModuleNotFoundError:
+    from dbt.contracts.graph.nodes import ColumnInfo  # type: ignore
+
+from dbt.artifacts.resources.v1.components import ColumnInfo
 import yaml
 from dbt.contracts.graph.node_args import ModelNodeArgs
 from dbt.contracts.graph.nodes import ModelNode
@@ -13,6 +19,7 @@ from dbt.plugins.manifest import PluginNodes
 from dbt.config.project import VarProvider
 
 from dbt_loom.shims import is_invalid_private_ref, is_invalid_protected_ref
+
 
 try:
     from dbt.artifacts.resources.types import NodeType
@@ -32,20 +39,48 @@ class LoomModelNodeArgs(ModelNodeArgs):
     """A dbt-loom extension of ModelNodeArgs to preserve resource types across lineages."""
 
     resource_type: NodeType = NodeType.Model
+    # This is a required field according to the JSON schema
+    # but needs a default value for dataclasse magic-init related reasons
+    original_file_path: Optional[str] = None
     group: Optional[str] = None
     event_time: Optional[str] = None
+    description: Optional[str] = None
+    tags: Optional[list[str]] = field(default_factory=list)
+    columns: Optional[dict[str, dict]] = None
+    compiled: Optional[bool] = None
+    raw_code: Optional[str] = None
+    compiled_code: Optional[str] = None
 
     def __init__(self, **kwargs):
         super().__init__(
             **{
                 key: value
                 for key, value in kwargs.items()
-                if key not in ("resource_type", "group", "config")
+                if key
+                not in (
+                    "resource_type",
+                    "group",
+                    "config",
+                    "description",
+                    "tags",
+                    "columns",
+                    "original_file_path",
+                    "raw_code",
+                    "compiled_code",
+                    "compiled",
+                )
             }
         )
         self.resource_type = kwargs.get("resource_type", NodeType.Model)
         self.group = kwargs.get("group")
         self.event_time = kwargs.get("config", {}).get("event_time", None)
+        self.original_file_path = kwargs.get("original_file_path", None)
+        self.description = kwargs.get("description", None)
+        self.tags = kwargs.get("tags", [])
+        self.columns = kwargs.get("columns", {})
+        self.compiled = kwargs.get("compiled", None)
+        self.raw_code = kwargs.get("raw_code", None)
+        self.compiled_code = kwargs.get("compiled_code", None)
 
     @property
     def unique_id(self) -> str:
@@ -151,6 +186,7 @@ class dbtLoom(dbtPlugin):
 
         if self.config is not None:
             self._patch_ref_protection()
+            self._patch_after_run()
 
         if not self.config or (self.config and not self.config.enable_telemetry):
             self._patch_plugin_telemetry()
@@ -215,6 +251,15 @@ class dbtLoom(dbtPlugin):
             model = function(args)
             model.group = args.group
             model.config.event_time = args.event_time
+            model.description = args.description
+            model.columns = (
+                {k: ColumnInfo.from_dict(v) for k, v in args.columns.items()}
+                if args.columns is not None
+                else {}
+            )
+            model.original_file_path = args.original_file_path
+            model.tags = args.tags
+
             return model
 
         return outer_function
@@ -245,6 +290,65 @@ class dbtLoom(dbtPlugin):
                     dependencies[manifest_name] = LoomRunnableConfig()
 
             return function(inner_self, node, target_model, dependencies)
+
+        return outer_function
+
+    def _patch_after_run(self) -> None:
+        """Patch `after_run` method to add more complete docs for injected nodes."""
+
+        from dbt.task.build import BuildTask
+        from dbt.task.compile import CompileTask
+
+        try:
+            from dbt.task.docs.generate import GenerateTask
+        except ModuleNotFoundError:
+            from dbt.task.generate import GenerateTask  # type: ignore
+        from dbt.task.run import RunTask
+
+        fire_event(
+            msg="dbt-loom: Patching after-run method to improve docs for injected nodes."
+        )
+
+        BuildTask.after_run = self.after_run_wrapper(  # type: ignore[method-assign]
+            BuildTask.after_run
+        )
+        CompileTask.after_run = self.after_run_wrapper(  # type: ignore[method-assign]
+            CompileTask.after_run
+        )
+        GenerateTask.after_run = self.after_run_wrapper(  # type: ignore[method-assign]
+            GenerateTask.after_run
+        )
+        RunTask.after_run = self.after_run_wrapper(RunTask.after_run)  # type: ignore[method-assign]
+
+    def after_run_wrapper(self, function) -> Callable:
+        """
+        Wrap the `after_run` method for GraphRunnableTasks to add extra node attrs for dbt docs.
+
+        These additionals attributes MUST be set after the compile phase is finished. Setting the
+        additional attributes prior to compile may result in compilation failures.
+
+        For example, because the plugin interface only injects ModelNodes in PluginNodes, compilation
+        will fail if the injected PluginNodes depend on macros defined in another dbt project, including
+        their own root project.
+        """
+        if TYPE_CHECKING:
+            from dbt.task.runnable import GraphRunnableTask
+
+        def outer_function(
+            task_instance: "GraphRunnableTask", adapter, results
+        ) -> None:
+            function(task_instance, adapter, results)
+            if task_instance.manifest is not None:
+                models = {
+                    node_id: node
+                    for node_id, node in task_instance.manifest.nodes.items()
+                    if node.resource_type == NodeType.Model
+                }
+                for node_id, node in models.items():
+                    if args := self.models.get(node_id, None):
+                        node.compiled = args.compiled or False
+                        node.raw_code = args.raw_code or ""
+                        node.compiled_code = args.compiled_code
 
         return outer_function
 

--- a/dbt_loom/manifests.py
+++ b/dbt_loom/manifests.py
@@ -8,6 +8,11 @@ import re
 from typing import Dict, List, Optional
 from urllib.parse import unquote, urlunparse
 
+try:
+    from dbt.artifacts.resources.v1.components import ColumnInfo
+except ModuleNotFoundError:
+    from dbt.contracts.graph.nodes import ColumnInfo  # type: ignore
+
 from pydantic import BaseModel, Field, validator
 import requests
 
@@ -53,6 +58,9 @@ class ManifestNode(BaseModel, use_enum_values=True):
     package_name: str
     unique_id: str
     resource_type: NodeType
+    # Used to render project filetree in docs site
+    # This is a required field according to the JSON schema https://schemas.getdbt.com/dbt/manifest/v12/index.html
+    original_file_path: str
     schema_name: str = Field(alias="schema")
     database: Optional[str] = None
     relation_name: Optional[str] = None
@@ -66,6 +74,12 @@ class ManifestNode(BaseModel, use_enum_values=True):
     depends_on_nodes: List[str] = Field(default_factory=list)
     enabled: bool = True
     config: dict = Field(default_factory=dict)
+    description: Optional[str] = None
+    columns: Optional[dict[str, ColumnInfo]] = None
+    tags: list[str] = Field(default_factory=list)
+    compiled: Optional[bool] = None
+    raw_code: Optional[str] = None
+    compiled_code: Optional[str] = None
 
     @validator("depends_on_nodes", always=True)
     def default_depends_on_nodes(cls, v, values):

--- a/tests/test_dbt_core_execution.py
+++ b/tests/test_dbt_core_execution.py
@@ -1,10 +1,21 @@
 import os
 from pathlib import Path
 
+import pytest
+import json
+
 import dbt
+
+try:
+    from dbt.artifacts.resources.types import NodeType
+except ModuleNotFoundError:
+    from dbt.node_types import NodeType  # type: ignore
+
+
 from dbt.cli.main import dbtRunner, dbtRunnerResult
 
 
+from dbt.contracts.graph.manifest import Manifest
 import dbt.exceptions
 
 
@@ -205,3 +216,37 @@ def test_dbt_loom_injects_microbatch_event_time():
         )
 
     os.chdir(starting_path)
+
+
+@pytest.mark.parametrize(
+    "cmd", [("build",), ("compile",), ("docs", "generate"), ("run",)]
+)
+def test_dbt_loom_injects_extra_node_attrs(cmd):
+    """Verify that dbt-loom sets attributes on injected models."""
+
+    extra_attrs = ["compiled", "compiled_code", "original_file_path", "raw_code"]
+    parent_project_name = "customer_success"
+
+    runner = dbtRunner()
+
+    os.chdir(f"{starting_path}/test_projects/revenue")
+    runner.invoke(["clean"])
+    runner.invoke(["deps"])
+    result = runner.invoke([*cmd])
+
+    assert result.exception is None
+
+    with open(f"{os.curdir}/target/manifest.json") as fp:
+        manifest = Manifest.from_dict(json.load(fp))
+
+    injected_models = {
+        node_id: node
+        for node_id, node in manifest.nodes.items()
+        if node.resource_type == NodeType.Model
+        and node.package_name == parent_project_name
+    }
+
+    assert injected_models
+
+    for model in injected_models.values():
+        assert all([hasattr(model, attr) for attr in extra_attrs])

--- a/tests/test_manifest_node.py
+++ b/tests/test_manifest_node.py
@@ -18,6 +18,7 @@ def test_rewrite_resource_types():
         "package_name": "example",
         "schema": "bar",
         "resource_type": "model",
+        "original_file_path": "seeds/example/foo",
     }
 
     manifest_node = ManifestNode(**(node))  # type: ignore
@@ -35,6 +36,7 @@ def test_rewrite_identifiers_true_negative():
         "schema": "bar",
         "resource_type": "model",
         "resource_name": "prod.bar.foo",
+        "original_file_path": "models/bar/foo",
     }
 
     manifest_node = ManifestNode(**(node))  # type: ignore
@@ -58,6 +60,7 @@ def test_rewrite_identifiers_true_positives(quote_char):
         "schema": "bar",
         "resource_type": "model",
         "relation_name": relation_name,
+        "original_file_path": "seed/example/foo",
     }
 
     manifest_node = ManifestNode(**(node))  # type: ignore

--- a/tests/test_manifest_references.py
+++ b/tests/test_manifest_references.py
@@ -28,6 +28,7 @@ def test_filter_nodes_from_excluded_packages_list():
         unique_id="model.bar.example",
         resource_type=NodeType.Model,
         schema="bar",
+        original_file_path="models/bar/foo",
     )
 
     assert not dbtLoom.filter_models(manifest_reference, node)
@@ -49,6 +50,7 @@ def test_filter_nodes_not_in_excluded_packages_list():
         unique_id="model.baz.example",
         resource_type=NodeType.Model,
         schema="baz",
+        original_file_path="models/baz/example",
     )
 
     assert dbtLoom.filter_models(manifest_reference, node)
@@ -69,6 +71,7 @@ def test_filter_nodes_not_in_included_packages_list():
         unique_id="model.baz.example",
         resource_type=NodeType.Model,
         schema="baz",
+        original_file_path="models/baz/example",
     )
 
     assert not dbtLoom.filter_models(manifest_reference, node)
@@ -89,6 +92,7 @@ def test_filter_nodes_in_included_packages_list():
         unique_id="model.bar.example",
         resource_type=NodeType.Model,
         schema="bar",
+        original_file_path="models/bar/example",
     )
 
     assert dbtLoom.filter_models(manifest_reference, node)

--- a/tests/test_node_deduplication.py
+++ b/tests/test_node_deduplication.py
@@ -24,6 +24,7 @@ def _make_node(unique_id, package_name, access="protected"):
         "schema": "core",
         "resource_type": "model",
         "access": access,
+        "original_file_path": "foo/bar/example",
     }
 
 


### PR DESCRIPTION
# Overview

This PR improves the documentation displayed for PluginNodes injected via this plugin. I poked around a bit in dbt-core and did some manual testing to identify the relevant node attributes used when rendering the docs site. 

I've tested this manually using a remote manifest stored in a GCS bucket and confirmed that the relevant documentation is correctly displayed. 

Resolves: #114 #119