### PR TITLE
feat: Enhance manifest reference resolution and add tests for config …

### DIFF
--- a/dbt_loom/config.py
+++ b/dbt_loom/config.py
@@ -4,7 +4,7 @@ import re
 from typing import List, Union
 from urllib.parse import ParseResult, urlparse
 
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field, field_validator, validator
 
 from dbt_loom.clients.az_blob import AzureReferenceConfig
 from dbt_loom.clients.dbt_cloud import DbtCloudReferenceConfig
@@ -49,6 +49,18 @@ class FileReferenceConfig(BaseModel):
         return urlparse(Path(v).absolute().as_uri())
 
 
+_TYPE_TO_CONFIG = {
+    ManifestReferenceType.file: FileReferenceConfig,
+    ManifestReferenceType.dbt_cloud: DbtCloudReferenceConfig,
+    ManifestReferenceType.paradime: ParadimeReferenceConfig,
+    ManifestReferenceType.gcs: GCSReferenceConfig,
+    ManifestReferenceType.s3: S3ReferenceConfig,
+    ManifestReferenceType.azure: AzureReferenceConfig,
+    ManifestReferenceType.snowflake: SnowflakeReferenceConfig,
+    ManifestReferenceType.databricks: DatabricksReferenceConfig,
+}
+
+
 class ManifestReference(BaseModel):
     """Reference information for a manifest to be loaded into dbt-loom."""
 
@@ -66,6 +78,25 @@ class ManifestReference(BaseModel):
     ]
     excluded_packages: List[str] = Field(default_factory=list)
     optional: bool = False
+
+    @field_validator("config", mode="before")
+    @classmethod
+    def resolve_config_type(cls, v, info):
+        """Resolve the config to the correct type based on the manifest
+        reference type.
+
+        Pydantic v1 Union resolution tries each type in order and returns the
+        first match. This can cause configs meant for other types (e.g.,
+        DatabricksReferenceConfig) to be incorrectly parsed as
+        FileReferenceConfig when both have a `path` field. This validator
+        explicitly constructs the correct config class based on `type`.
+        """
+        ref_type = info.data.get("type")
+        if ref_type is not None and isinstance(v, dict):
+            config_cls = _TYPE_TO_CONFIG.get(ref_type)
+            if config_cls is not None:
+                return config_cls(**v)
+        return v
 
 
 class dbtLoomConfig(BaseModel):

--- a/tests/test_manifest_loaders.py
+++ b/tests/test_manifest_loaders.py
@@ -11,6 +11,7 @@ from dbt_loom.config import (
     ManifestReferenceType,
     LoomConfigurationError,
 )
+from dbt_loom.clients.dbx import DatabricksReferenceConfig
 from dbt_loom.manifests import ManifestLoader, UnknownManifestPathType
 
 
@@ -130,3 +131,24 @@ def test_load_from_local_filesystem_not_optional_missing():
     manifest_loader = ManifestLoader()
     with pytest.raises(LoomConfigurationError):
         manifest_loader.load(manifest_reference)
+
+
+def test_manifest_reference_resolves_databricks_config():
+    """Verify that type=databricks produces DatabricksReferenceConfig, not FileReferenceConfig."""
+    ref = ManifestReference(
+        name="test_dbx",
+        type=ManifestReferenceType.databricks,
+        config={"path": "/Volumes/my_catalog/my_schema/my_volume/manifest.json.gz"},
+    )
+    assert isinstance(ref.config, DatabricksReferenceConfig)
+    assert ref.config.path == "/Volumes/my_catalog/my_schema/my_volume/manifest.json.gz"
+
+
+def test_manifest_reference_resolves_file_config():
+    """Verify that type=file still produces FileReferenceConfig."""
+    ref = ManifestReference(
+        name="test_file",
+        type=ManifestReferenceType.file,
+        config={"path": "manifest.json"},
+    )
+    assert isinstance(ref.config, FileReferenceConfig)


### PR DESCRIPTION
my attempt to fix #161.
I tested this on macos and windows.

The Issue was, that Pydantic resolves Unions by trying each type in order, returning the first match.

Since both `FileReferenceConfig` and `DatabricksReferenceConfig` have a `path` field and `FileReferenceConfig` is listed first — so Databricks configs were silently parsed as file configs:
https://github.com/nicholasyager/dbt-loom/blob/d0b89e62b8a12d560a4686a8ad6b21a0ef9b78fe/dbt_loom/config.py#L57-L66

Resulting in:
`FileReferenceConfig` then runs `Path(v).absolute().as_uri()`, which on Windows prepends `C:/` to the Databricks volume path.