### PR TITLE
feat: Add configuration to allow downstream project database name aliasing

### DIFF
--- a/dbt_loom/__init__.py
+++ b/dbt_loom/__init__.py
@@ -86,6 +86,26 @@ def identify_node_subgraph(manifest) -> Dict[str, ManifestNode]:
     return output
 
 
+def apply_database_alias(
+    nodes: Dict[str, ManifestNode],
+    database_alias: Dict[str, str],
+) -> Dict[str, ManifestNode]:
+    """Apply database name aliases to ManifestNodes."""
+    if not database_alias:
+        return nodes
+
+    for node in nodes.values():
+        if node.database and node.database in database_alias:
+            original_db = node.database
+            alias_db = database_alias[original_db]
+            node.database = alias_db
+
+            if node.relation_name:
+                node.relation_name = node.relation_name.replace(original_db, alias_db, 1)
+
+    return nodes
+
+
 def convert_model_nodes_to_model_node_args(
     selected_nodes: Dict[str, ManifestNode],
 ) -> Dict[str, LoomModelNodeArgs]:
@@ -284,6 +304,15 @@ class dbtLoom(dbtPlugin):
             self.manifests[manifest_name] = manifest
 
             selected_nodes = identify_node_subgraph(manifest)
+
+            if manifest_reference.database_alias:
+                fire_event(
+                    msg=f"dbt-loom: Applying database overrides for `{manifest_reference.name}`: "
+                    f"{manifest_reference.database_alias}"
+                )
+                selected_nodes = apply_database_alias(
+                    selected_nodes, manifest_reference.database_alias
+                )
 
             # Remove nodes from excluded packages.
             filtered_nodes = {

--- a/dbt_loom/config.py
+++ b/dbt_loom/config.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from pathlib import Path
 import re
-from typing import List, Union
+from typing import Dict, List, Union
 from urllib.parse import ParseResult, urlparse
 
 from pydantic import BaseModel, Field, validator
@@ -65,6 +65,7 @@ class ManifestReference(BaseModel):
         DatabricksReferenceConfig,
     ]
     excluded_packages: List[str] = Field(default_factory=list)
+    database_alias: Dict[str, str] = Field(default_factory=dict)
     optional: bool = False
 
 

--- a/docs/advanced-configuration.md
+++ b/docs/advanced-configuration.md
@@ -76,8 +76,12 @@ the upstream database. The database name can be aliased using the `database_alia
 property in the `dbt_loom.config.yml` file.
 
 ```yaml
-database_alias:
-  original_database_name1: alias_database_name1
-  original_database_name2: alias_database_name2
-manifests: ...
+manifests:
+  - name: revenue
+    type: file
+    config:
+      path: ../revenue/target/manifest.json
+      database_alias:
+        upstream_database_1: downstream_database_1
+        upstream_database_2: downstream_database_2
 ```

--- a/docs/advanced-configuration.md
+++ b/docs/advanced-configuration.md
@@ -81,7 +81,7 @@ manifests:
     type: file
     config:
       path: ../revenue/target/manifest.json
-      database_alias:
-        upstream_database_1: downstream_database_1
-        upstream_database_2: downstream_database_2
+    database_alias:
+      upstream_database_1: downstream_database_1
+      upstream_database_2: downstream_database_2
 ```

--- a/docs/advanced-configuration.md
+++ b/docs/advanced-configuration.md
@@ -65,3 +65,19 @@ in the `dbt_loom.config.yml` file.
 enable_telemetry: true
 manifests: ...
 ```
+
+## Alias Database Names
+
+In some circumstances, you might need to reference an aliased database name in
+the downstream project that differs from the originating database name in the
+upstream project. For example, in Microsoft Fabric cross-workspace queries can
+only be made using OneLake shortcuts rather than having direct query access to
+the upstream database. The database name can be aliased using the `database_alias`
+property in the `dbt_loom.config.yml` file.
+
+```yaml
+database_alias:
+  original_database_name1: alias_database_name1
+  original_database_name2: alias_database_name2
+manifests: ...
+```

--- a/tests/test_dbt_core_execution.py
+++ b/tests/test_dbt_core_execution.py
@@ -1,6 +1,8 @@
 import os
+import shutil
 from pathlib import Path
 
+import yaml
 import dbt
 from dbt.cli.main import dbtRunner, dbtRunnerResult
 
@@ -163,6 +165,7 @@ def test_dbt_core_telemetry_blocking():
 
     os.chdir(starting_path)
 
+
 def test_dbt_loom_injects_microbatch_event_time():
     """Verify that dbt-loom injects the 'event_time' property to allow proper microbatch configuration"""
     import shutil
@@ -204,3 +207,40 @@ def test_dbt_loom_injects_microbatch_event_time():
         assert "has no 'ref' or 'source' input with an 'event_time' configuration" not in log_contents
 
     os.chdir(starting_path)
+
+
+def test_dbt_loom_database_alias():
+    """Verify that database_alias remaps database names on injected nodes."""
+
+    runner = dbtRunner()
+
+    # Compile the revenue project first
+    os.chdir(f"{starting_path}/test_projects/revenue")
+    runner.invoke(["clean"])
+    runner.invoke(["deps"])
+    runner.invoke(["compile"])
+
+    # Temporarily modify the customer_success config to include a database alias
+    config_path = Path(f"{starting_path}/test_projects/customer_success/dbt_loom.config.yml")
+    original_config = config_path.read_text()
+
+    alias_config = yaml.safe_load(original_config)
+    alias_config["manifests"][0]["database_alias"] = {"database": "aliased_db"}
+
+    try:
+        config_path.write_text(yaml.dump(alias_config))
+
+        os.chdir(f"{starting_path}/test_projects/customer_success")
+        runner.invoke(["clean"])
+        runner.invoke(["deps"])
+        shutil.rmtree("logs", ignore_errors=True)
+        output: dbtRunnerResult = runner.invoke(["compile"])
+
+        with open("logs/dbt.log") as log_file:
+            log_contents = log_file.read()
+
+        assert "Applying database overrides" in log_contents
+        assert "aliased_db" in log_contents
+    finally:
+        config_path.write_text(original_config)
+        os.chdir(starting_path)

--- a/tests/test_mainfest_node.py
+++ b/tests/test_mainfest_node.py
@@ -1,10 +1,24 @@
+from dbt_loom import apply_database_alias
 from dbt_loom.manifests import ManifestNode
+from dbt_loom.config import ManifestReference, ManifestReferenceType, FileReferenceConfig
 
 
 try:
     from dbt.artifacts.resources.types import NodeType
 except ModuleNotFoundError:
     from dbt.node_types import NodeType  # type: ignore
+
+
+def _make_node(name, database=None, relation_name=None):
+    return ManifestNode(
+        unique_id=f"model.pkg.{name}",
+        name=name,
+        package_name="pkg",
+        schema="main",
+        resource_type="model",
+        database=database,
+        relation_name=relation_name,
+    )
 
 
 def test_rewrite_resource_types():
@@ -21,3 +35,45 @@ def test_rewrite_resource_types():
     manifest_node = ManifestNode(**(node))  # type: ignore
 
     assert manifest_node.resource_type == NodeType.Seed
+
+
+def test_apply_database_alias_empty():
+    """Confirm empty override dict is a no-op for backwards compatibility."""
+    node = _make_node("my_model", "db1", '"db1"."schema"."table"')
+    nodes = {"model.pkg.my_model": node}
+
+    result = apply_database_alias(nodes, {})
+
+    assert result["model.pkg.my_model"].database == "db1"
+
+
+def test_apply_database_alias_basic():
+    """Confirm that database and relation_name are both overridden."""
+    node1 = _make_node("my_model1", "db1", '"db1"."schema"."table"')
+    node2 = _make_node("my_model2", "db1", "`db1`.`schema`.`table`")
+    node3 = _make_node("my_model3", "db2", '"db2"."schema"."table"')
+    node4 = _make_node("my_model4", None, None)
+    nodes = {
+        "model.pkg.my_model1": node1,
+        "model.pkg.my_model2": node2,
+        "model.pkg.my_model3": node3,
+        "model.pkg.my_model4": node4
+    }
+
+    result = apply_database_alias(nodes, {"db1": "db1_alias"})
+
+    # Alias provided
+    assert result["model.pkg.my_model1"].database == "db1_alias"
+    assert result["model.pkg.my_model1"].relation_name == '"db1_alias"."schema"."table"'
+
+    # Alias provided with backticks (BigQuery style)
+    assert result["model.pkg.my_model2"].database == "db1_alias"
+    assert result["model.pkg.my_model2"].relation_name == '`db1_alias`.`schema`.`table`'
+
+    # No alias provided
+    assert result["model.pkg.my_model3"].database == "db2"
+    assert result["model.pkg.my_model3"].relation_name == '"db2"."schema"."table"'
+
+    # No node
+    assert result["model.pkg.my_model4"].database is None
+    assert result["model.pkg.my_model4"].relation_name is None

--- a/tests/test_mainfest_reference.py
+++ b/tests/test_mainfest_reference.py
@@ -1,0 +1,22 @@
+from dbt_loom.config import ManifestReference, ManifestReferenceType, FileReferenceConfig
+
+
+def test_manifest_reference_with_database_alias():
+    """Confirm ManifestReference accepts database_alias."""
+    ref = ManifestReference(
+        name="test",
+        type=ManifestReferenceType.file,
+        config=FileReferenceConfig(path="./manifest.json"),
+        database_alias={"prod_db": "dev_db"},
+    )
+    assert ref.database_alias == {"prod_db": "dev_db"}
+
+
+def test_manifest_reference_default_database_alias():
+    """Confirm ManifestReference defaults database_alias to empty dict."""
+    ref = ManifestReference(
+        name="test",
+        type=ManifestReferenceType.file,
+        config=FileReferenceConfig(path="./manifest.json"),
+    )
+    assert ref.database_alias == {}


### PR DESCRIPTION
## Summary

Adds a `database_alias` configuration option to manifest references, allowing users to remap database names when consuming an upstream manifest.

```yaml
manifests:
  - name: revenue
    type: file
    config:
      path: ./target/manifest.json
    database_alias:
      upstream_db: downstream_db
```

## Motivation
In environments like Microsoft Fabric, cross-workspace querying is not natively supported. The workaround is to create OneLake shortcuts that mirror upstream tables into the downstream workspace. While the shortcutted database can use the same name as the upstream source, this leads to confusing duplicate names across workspaces. Ideally, the shortcut would use a distinct name — but dbt-loom currently injects nodes with the original database name from the upstream manifest, with no way to override it.

This change allows the downstream project to alias the database name so that injected nodes point to the shortcutted database rather than the original.

I am not sure if this change will be accepted as it's somewhat specific but is also a very common usecase in Microsoft Fabric where workspaces are designed to be the logical boundaries. If you have a medallion architecture, bronze, silver, and gold would likely be separate workspaces where silver needs to connect to bronze and gold needs to connect to silver.

## Changes
- `dbt_loom/config.py` — Added `database_alias: Dict[str, str]` field to `ManifestReference` (defaults to {}, fully backward-compatible)
- `dbt_loom/__init__.py` — Added `apply_database_alias()` function that remaps `ManifestNode.database` and the database portion of `ManifestNode.relation_name`; wired into `initialize()` with logging
- `tests/` — Added unit tests and an e2e test validating the alias is applied during compilation