### PR TITLE
Fix: Prevent transitive dependency copies from overwriting authoritative node access levels

### DIFF
--- a/dbt_loom/__init__.py
+++ b/dbt_loom/__init__.py
@@ -101,6 +101,24 @@ def convert_model_nodes_to_model_node_args(
     }
 
 
+def merge_loom_nodes(
+    existing_nodes: Dict[str, LoomModelNodeArgs],
+    new_nodes: Dict[str, LoomModelNodeArgs],
+    manifest_name: str,
+) -> None:
+    """Merge ``new_nodes`` from a manifest into ``existing_nodes`` in place.
+
+    Nodes owned by this manifest's project are authoritative and should
+    always be used. Transitive dependency nodes (from other packages) should
+    only be added if not already provided by a previous, more authoritative
+    manifest.
+    """
+    for key, value in new_nodes.items():
+        is_authoritative = value.package_name == manifest_name
+        if is_authoritative or key not in existing_nodes:
+            existing_nodes[key] = value
+
+
 @dataclass
 class LoomRunnableConfig:
     """A shim class to allow is_invalid_*_ref functions to correctly handle access for loom-injected models."""
@@ -294,14 +312,7 @@ class dbtLoom(dbtPlugin):
 
             loom_nodes = convert_model_nodes_to_model_node_args(filtered_nodes)
 
-            # Nodes owned by this manifest's project are authoritative and
-            # should always be used. Transitive dependency nodes (from other
-            # packages) should only be added if not already provided by a
-            # previous, more authoritative manifest.
-            for key, value in loom_nodes.items():
-                is_authoritative = value.package_name == manifest_name
-                if is_authoritative or key not in self.models:
-                    self.models[key] = value
+            merge_loom_nodes(self.models, loom_nodes, manifest_name)
 
     @dbt_hook
     def get_nodes(self) -> PluginNodes:

--- a/dbt_loom/__init__.py
+++ b/dbt_loom/__init__.py
@@ -294,7 +294,14 @@ class dbtLoom(dbtPlugin):
 
             loom_nodes = convert_model_nodes_to_model_node_args(filtered_nodes)
 
-            self.models.update(loom_nodes)
+            # Nodes owned by this manifest's project are authoritative and
+            # should always be used. Transitive dependency nodes (from other
+            # packages) should only be added if not already provided by a
+            # previous, more authoritative manifest.
+            for key, value in loom_nodes.items():
+                is_authoritative = value.package_name == manifest_name
+                if is_authoritative or key not in self.models:
+                    self.models[key] = value
 
     @dbt_hook
     def get_nodes(self) -> PluginNodes:

--- a/tests/test_node_deduplication.py
+++ b/tests/test_node_deduplication.py
@@ -1,0 +1,138 @@
+"""Tests for node deduplication when the same node appears in multiple upstream manifests."""
+
+from dbt_loom import identify_node_subgraph, convert_model_nodes_to_model_node_args
+
+
+def _make_manifest(project_name, nodes):
+    """Helper to create a minimal manifest dict."""
+    return {
+        "metadata": {"project_name": project_name},
+        "nodes": nodes,
+    }
+
+
+def _make_node(unique_id, package_name, access="protected"):
+    """Helper to create a minimal manifest node dict."""
+    return {
+        "unique_id": unique_id,
+        "name": unique_id.split(".")[-1],
+        "package_name": package_name,
+        "schema": "core",
+        "resource_type": "model",
+        "access": access,
+    }
+
+
+def _merge_manifests(manifest_pairs):
+    """Simulate the initialize() merging logic from dbtLoom.
+
+    Args:
+        manifest_pairs: list of (manifest_dict, project_name) tuples in load order.
+    """
+    models = {}
+    for manifest, manifest_name in manifest_pairs:
+        selected_nodes = identify_node_subgraph(manifest)
+        loom_nodes = convert_model_nodes_to_model_node_args(selected_nodes)
+        for key, value in loom_nodes.items():
+            is_authoritative = value.package_name == manifest_name
+            if is_authoritative or key not in models:
+                models[key] = value
+    return models
+
+
+def test_authoritative_node_wins_over_transitive_copy():
+    """The owning manifest's public node should not be overwritten by a
+    protected transitive copy from a later manifest."""
+
+    uid = "model.project_a.shared_model"
+
+    models = _merge_manifests(
+        [
+            (
+                _make_manifest(
+                    "project_a", {uid: _make_node(uid, "project_a", access="public")}
+                ),
+                "project_a",
+            ),
+            (
+                _make_manifest(
+                    "project_b", {uid: _make_node(uid, "project_a", access="protected")}
+                ),
+                "project_b",
+            ),
+        ]
+    )
+
+    assert models[uid].access == "public"
+
+
+def test_authoritative_node_wins_regardless_of_load_order():
+    """Even if the transitive copy is loaded first, the authoritative manifest
+    should overwrite it."""
+
+    uid = "model.project_a.shared_model"
+
+    models = _merge_manifests(
+        [
+            (
+                _make_manifest(
+                    "project_b", {uid: _make_node(uid, "project_a", access="protected")}
+                ),
+                "project_b",
+            ),
+            (
+                _make_manifest(
+                    "project_a", {uid: _make_node(uid, "project_a", access="public")}
+                ),
+                "project_a",
+            ),
+        ]
+    )
+
+    assert models[uid].access == "public"
+
+
+def test_transitive_node_added_when_no_authoritative_source():
+    """Nodes from packages without their own manifest entry should still be
+    injected via the first manifest that provides them."""
+
+    uid = "model.project_c.some_model"
+
+    models = _merge_manifests(
+        [
+            (
+                _make_manifest(
+                    "project_a", {uid: _make_node(uid, "project_c", access="protected")}
+                ),
+                "project_a",
+            ),
+        ]
+    )
+
+    assert uid in models
+
+
+def test_first_transitive_copy_preserved_over_later_copies():
+    """When a non-authoritative node appears in multiple manifests, the first
+    loaded version should be kept."""
+
+    uid = "model.project_c.some_model"
+
+    models = _merge_manifests(
+        [
+            (
+                _make_manifest(
+                    "project_a", {uid: _make_node(uid, "project_c", access="public")}
+                ),
+                "project_a",
+            ),
+            (
+                _make_manifest(
+                    "project_b", {uid: _make_node(uid, "project_c", access="protected")}
+                ),
+                "project_b",
+            ),
+        ]
+    )
+
+    assert models[uid].access == "public"

--- a/tests/test_node_deduplication.py
+++ b/tests/test_node_deduplication.py
@@ -1,6 +1,10 @@
 """Tests for node deduplication when the same node appears in multiple upstream manifests."""
 
-from dbt_loom import identify_node_subgraph, convert_model_nodes_to_model_node_args
+from dbt_loom import (
+    convert_model_nodes_to_model_node_args,
+    identify_node_subgraph,
+    merge_loom_nodes,
+)
 
 
 def _make_manifest(project_name, nodes):
@@ -33,10 +37,7 @@ def _merge_manifests(manifest_pairs):
     for manifest, manifest_name in manifest_pairs:
         selected_nodes = identify_node_subgraph(manifest)
         loom_nodes = convert_model_nodes_to_model_node_args(selected_nodes)
-        for key, value in loom_nodes.items():
-            is_authoritative = value.package_name == manifest_name
-            if is_authoritative or key not in models:
-                models[key] = value
+        merge_loom_nodes(models, loom_nodes, manifest_name)
     return models
 
 


### PR DESCRIPTION
### Problem
When multiple upstream manifests are configured in dbt-loom, a node can appear in more than one manifest -- once in its owning project's manifest (authoritative) and again as a transitive dependency in other projects' manifests. The existing self.models.update(loom_nodes) logic blindly overwrites previously loaded nodes, so the last-loaded manifest wins.
This causes a bug where a node marked access: public in its owning manifest gets overwritten by a access: protected transitive copy from a later manifest, resulting in:
Parsing Error
  Node model.project_a.my_model attempted to reference node
  model.project_b.shared_model, which is not allowed because the
  referenced node is protected to the 'project_b' package.
### Root Cause
In dbtLoom.initialize(), manifests are loaded sequentially and their nodes are merged with self.models.update(loom_nodes). When a downstream project's manifest (e.g., external_standard_and_policy_mgmt) includes a transitive copy of a node from an upstream project (e.g., customer_relation_modelling) with access: protected, it silently overwrites the authoritative access: public version that was already loaded.
Fix
Replace the unconditional self.models.update(loom_nodes) with authoritative-first merge logic:
- Authoritative nodes (package_name matches the manifest's project): always written -- the owning project is the source of truth for its own nodes.
- Transitive dependency nodes (package_name differs from the manifest's project): only added if the node hasn't already been provided by a previous manifest.
### Tests Added
tests/test_node_deduplication.py -- 4 unit tests covering:
- Authoritative public node is preserved when a later manifest has a protected transitive copy
- Authoritative node wins regardless of manifest loading order
- Transitive dependency nodes are still injected when no authoritative source exists
- First-loaded transitive copy is preserved over later duplicates