### PR TITLE
feat: Add node transformer hook system

### DIFF
--- a/dbt_loom/__init__.py
+++ b/dbt_loom/__init__.py
@@ -20,7 +20,8 @@ except ModuleNotFoundError:
     from dbt.node_types import NodeType  # type: ignore
 
 
-from dbt_loom.config import dbtLoomConfig
+from dbt_loom.config import LoomConfigurationError, dbtLoomConfig
+from dbt_loom.transformers import TransformerContext, chain_transformers, resolve_transformer
 from dbt_loom.logging import fire_event
 from dbt_loom.manifests import ManifestLoader, ManifestNode
 
@@ -84,6 +85,7 @@ def identify_node_subgraph(manifest) -> Dict[str, ManifestNode]:
         output[unique_id] = ManifestNode(**(node))
 
     return output
+
 
 
 def convert_model_nodes_to_model_node_args(
@@ -284,6 +286,31 @@ class dbtLoom(dbtPlugin):
             self.manifests[manifest_name] = manifest
 
             selected_nodes = identify_node_subgraph(manifest)
+
+            # Resolve and apply user-defined node transformers.
+            transformers = []
+            for path in manifest_reference.node_transformers:
+                fire_event(
+                    msg=f"dbt-loom: Loading node transformer `{path}` "
+                    f"for `{manifest_reference.name}`"
+                )
+                try:
+                    transformers.append(resolve_transformer(path))
+                except (ImportError, AttributeError, TypeError) as e:
+                    raise LoomConfigurationError(
+                        f"Failed to load node transformer '{path}' for "
+                        f"manifest '{manifest_reference.name}': {e}"
+                    ) from e
+
+            if transformers:
+                context = TransformerContext(
+                    manifest_name=manifest_name,
+                    manifest_reference_name=manifest_reference.name,
+                    raw_manifest=manifest,
+                )
+                selected_nodes = chain_transformers(transformers)(
+                    selected_nodes, context
+                )
 
             # Remove nodes from excluded packages.
             filtered_nodes = {

--- a/dbt_loom/config.py
+++ b/dbt_loom/config.py
@@ -65,6 +65,7 @@ class ManifestReference(BaseModel):
         DatabricksReferenceConfig,
     ]
     excluded_packages: List[str] = Field(default_factory=list)
+    node_transformers: List[str] = Field(default_factory=list)
     optional: bool = False
 
 

--- a/dbt_loom/transformers.py
+++ b/dbt_loom/transformers.py
@@ -1,0 +1,69 @@
+import importlib
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Protocol, Sequence
+
+from dbt_loom.manifests import ManifestNode
+
+
+@dataclass(frozen=True)
+class TransformerContext:
+    """Contextual information passed to node transformers."""
+
+    manifest_name: str
+    manifest_reference_name: str
+    raw_manifest: Dict[str, Any]
+
+
+class NodeTransformer(Protocol):
+    """Protocol for node transformers.
+
+    A NodeTransformer is any callable that accepts a dict of selected nodes
+    and a TransformerContext, and returns a (potentially modified) dict of nodes.
+    """
+
+    def __call__(
+        self,
+        nodes: Dict[str, ManifestNode],
+        context: TransformerContext,
+    ) -> Dict[str, ManifestNode]: ...
+
+
+def resolve_transformer(dotted_path: str) -> NodeTransformer:
+    """Import and return a callable from a dotted Python path.
+
+    Example: "my_package.transforms.rewrite_schemas" resolves to the function object.
+    """
+    module_path, _, attr_name = dotted_path.rpartition(".")
+    if not module_path:
+        raise ImportError(
+            f"Invalid transformer path '{dotted_path}': must be a fully qualified "
+            "dotted path like 'my_module.my_function'"
+        )
+    module = importlib.import_module(module_path)
+    transformer = getattr(module, attr_name)
+    if not callable(transformer):
+        raise TypeError(
+            f"Transformer '{dotted_path}' resolved to {type(transformer)}, "
+            "which is not callable."
+        )
+    return transformer
+
+
+def chain_transformers(
+    transformers: Sequence[NodeTransformer],
+) -> NodeTransformer:
+    """Compose multiple transformers into a single transformer.
+
+    Transformers are applied in order (first to last). Each receives
+    the output of the previous one.
+    """
+
+    def chained(
+        nodes: Dict[str, ManifestNode],
+        context: TransformerContext,
+    ) -> Dict[str, ManifestNode]:
+        for transformer in transformers:
+            nodes = transformer(nodes, context)
+        return nodes
+
+    return chained

--- a/docs/advanced-configuration.md
+++ b/docs/advanced-configuration.md
@@ -65,3 +65,69 @@ in the `dbt_loom.config.yml` file.
 enable_telemetry: true
 manifests: ...
 ```
+
+## Custom Manifest Node Transformers
+
+You can apply custom transformations to nodes after they are loaded from
+upstream manifests. Each transformer is a Python callable that receives
+the selected nodes and a context object, and returns the (potentially modified)
+nodes dictionary.
+
+### Writing a transformer
+
+Create a Python module in your project or an installable package:
+
+```python
+# my_company/dbt_transforms.py
+from dbt_loom.transformers import TransformerContext
+from dbt_loom.manifests import ManifestNode
+
+
+def rewrite_databases(
+    nodes: dict[str, ManifestNode],
+    context: TransformerContext,
+) -> dict[str, ManifestNode]:
+    """Rewrite database names using an alias mapping."""
+    alias_map = {"upstream_db": "downstream_db"}
+
+    for node in nodes.values():
+        if node.database and node.database in alias_map:
+            original_db = node.database
+            alias_db = alias_map[original_db]
+            node.database = alias_db
+            if node.relation_name:
+                node.relation_name = node.relation_name.replace(
+                    original_db, alias_db, 1
+                )
+    return nodes
+```
+
+The `TransformerContext` provides:
+
+- `manifest_name` — the resolved project name from manifest metadata
+- `manifest_reference_name` — the `name` field from your config
+- `raw_manifest` — the full manifest dictionary, for advanced use cases
+
+### Configuring transformers
+
+Add dotted Python import paths to the `node_transformers` list for a manifest
+reference. Transformers are applied in the order listed.
+
+```yaml
+manifests:
+  - name: revenue
+    type: file
+    config:
+      path: ../revenue/target/manifest.json
+    node_transformers:
+      - "my_company.dbt_transforms.rewrite_databases"
+```
+
+### Execution order
+
+For each manifest reference, the node processing pipeline is:
+
+1. Parse raw manifest into `ManifestNode` objects
+2. Apply `node_transformers` in list order
+3. Filter out `excluded_packages`
+4. Convert to dbt-injectable node args

--- a/tests/test_dbt_core_execution.py
+++ b/tests/test_dbt_core_execution.py
@@ -1,6 +1,8 @@
 import os
+import shutil
 from pathlib import Path
 
+import yaml
 import dbt
 from dbt.cli.main import dbtRunner, dbtRunnerResult
 
@@ -163,6 +165,7 @@ def test_dbt_core_telemetry_blocking():
 
     os.chdir(starting_path)
 
+
 def test_dbt_loom_injects_microbatch_event_time():
     """Verify that dbt-loom injects the 'event_time' property to allow proper microbatch configuration"""
     import shutil
@@ -204,3 +207,5 @@ def test_dbt_loom_injects_microbatch_event_time():
         assert "has no 'ref' or 'source' input with an 'event_time' configuration" not in log_contents
 
     os.chdir(starting_path)
+
+

--- a/tests/test_dbt_core_execution.py
+++ b/tests/test_dbt_core_execution.py
@@ -1,8 +1,6 @@
 import os
-import shutil
 from pathlib import Path
 
-import yaml
 import dbt
 from dbt.cli.main import dbtRunner, dbtRunnerResult
 
@@ -165,7 +163,6 @@ def test_dbt_core_telemetry_blocking():
 
     os.chdir(starting_path)
 
-
 def test_dbt_loom_injects_microbatch_event_time():
     """Verify that dbt-loom injects the 'event_time' property to allow proper microbatch configuration"""
     import shutil
@@ -207,5 +204,3 @@ def test_dbt_loom_injects_microbatch_event_time():
         assert "has no 'ref' or 'source' input with an 'event_time' configuration" not in log_contents
 
     os.chdir(starting_path)
-
-

--- a/tests/test_mainfest_reference.py
+++ b/tests/test_mainfest_reference.py
@@ -1,0 +1,22 @@
+from dbt_loom.config import ManifestReference, ManifestReferenceType, FileReferenceConfig
+
+
+def test_manifest_reference_with_node_transformers():
+    """Confirm ManifestReference accepts node_transformers."""
+    ref = ManifestReference(
+        name="test",
+        type=ManifestReferenceType.file,
+        config=FileReferenceConfig(path="./manifest.json"),
+        node_transformers=["my_module.my_function"],
+    )
+    assert ref.node_transformers == ["my_module.my_function"]
+
+
+def test_manifest_reference_default_node_transformers():
+    """Confirm ManifestReference defaults node_transformers to empty list."""
+    ref = ManifestReference(
+        name="test",
+        type=ManifestReferenceType.file,
+        config=FileReferenceConfig(path="./manifest.json"),
+    )
+    assert ref.node_transformers == []

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -1,0 +1,181 @@
+import pytest
+
+from dbt_loom.manifests import ManifestNode
+from dbt_loom.transformers import (
+    TransformerContext,
+    chain_transformers,
+    resolve_transformer,
+)
+
+
+def _make_node(name, database=None, relation_name=None):
+    return ManifestNode(
+        unique_id=f"model.pkg.{name}",
+        name=name,
+        package_name="pkg",
+        schema="main",
+        resource_type="model",
+        database=database,
+        relation_name=relation_name,
+    )
+
+
+_DUMMY_CTX = TransformerContext(
+    manifest_name="test",
+    manifest_reference_name="test",
+    raw_manifest={},
+)
+
+
+def test_resolve_transformer():
+    """Resolve a known stdlib callable via dotted path."""
+    transformer = resolve_transformer("json.loads")
+    assert callable(transformer)
+
+
+def test_resolve_transformer_invalid_path():
+    """Raise ImportError for a non-existent module."""
+    with pytest.raises(ImportError):
+        resolve_transformer("nonexistent_module_xyz.func")
+
+
+def test_resolve_transformer_bare_name():
+    """Raise ImportError for a bare name without module path."""
+    with pytest.raises(ImportError, match="must be a fully qualified"):
+        resolve_transformer("bare_name")
+
+
+def test_resolve_transformer_not_callable():
+    """Raise TypeError when the resolved attribute is not callable."""
+    with pytest.raises(TypeError, match="not callable"):
+        resolve_transformer("os.sep")
+
+
+def test_chain_transformers_empty():
+    """An empty chain is a no-op."""
+    nodes = {"model.pkg.a": _make_node("a", "db1")}
+    chained = chain_transformers([])
+    result = chained(nodes, _DUMMY_CTX)
+    assert result == nodes
+
+
+def test_chain_transformers_ordering():
+    """Transformers execute in list order, each receiving the previous output."""
+    call_order = []
+
+    def first(nodes, context):
+        call_order.append("first")
+        for node in nodes.values():
+            node.database = "after_first"
+        return nodes
+
+    def second(nodes, context):
+        call_order.append("second")
+        # Verify it sees the output of 'first'
+        for node in nodes.values():
+            assert node.database == "after_first"
+            node.database = "after_second"
+        return nodes
+
+    nodes = {"model.pkg.a": _make_node("a", "original")}
+    chained = chain_transformers([first, second])
+    result = chained(nodes, _DUMMY_CTX)
+
+    assert call_order == ["first", "second"]
+    assert result["model.pkg.a"].database == "after_second"
+
+
+def test_transformer_context_passed():
+    """Verify the context object is forwarded to transformers."""
+    received_contexts = []
+
+    def capture_context(nodes, context):
+        received_contexts.append(context)
+        return nodes
+
+    ctx = TransformerContext(
+        manifest_name="revenue",
+        manifest_reference_name="rev_ref",
+        raw_manifest={"metadata": {"project_name": "revenue"}},
+    )
+    nodes = {"model.pkg.a": _make_node("a")}
+    chain_transformers([capture_context])(nodes, ctx)
+
+    assert len(received_contexts) == 1
+    assert received_contexts[0].manifest_name == "revenue"
+    assert received_contexts[0].manifest_reference_name == "rev_ref"
+    assert received_contexts[0].raw_manifest == {"metadata": {"project_name": "revenue"}}
+
+
+def test_database_alias_as_transformer():
+    """Prove that a database-alias transformation can be achieved via the hook system.
+
+    This replicates the behavior of the old apply_database_alias function
+    using a custom transformer, validating that the hook system is sufficient.
+    """
+    alias_map = {"db1": "db1_alias"}
+
+    def database_alias_transformer(nodes, context):
+        for node in nodes.values():
+            if node.database and node.database in alias_map:
+                original_db = node.database
+                alias_db = alias_map[original_db]
+                node.database = alias_db
+                if node.relation_name:
+                    node.relation_name = node.relation_name.replace(original_db, alias_db, 1)
+        return nodes
+
+    node1 = _make_node("my_model1", "db1", '"db1"."schema"."table"')
+    node2 = _make_node("my_model2", "db1", "`db1`.`schema`.`table`")
+    node3 = _make_node("my_model3", "db2", '"db2"."schema"."table"')
+    node4 = _make_node("my_model4", None, None)
+    nodes = {
+        "model.pkg.my_model1": node1,
+        "model.pkg.my_model2": node2,
+        "model.pkg.my_model3": node3,
+        "model.pkg.my_model4": node4,
+    }
+
+    result = chain_transformers([database_alias_transformer])(nodes, _DUMMY_CTX)
+
+    # Alias applied
+    assert result["model.pkg.my_model1"].database == "db1_alias"
+    assert result["model.pkg.my_model1"].relation_name == '"db1_alias"."schema"."table"'
+
+    # Alias applied with backticks
+    assert result["model.pkg.my_model2"].database == "db1_alias"
+    assert result["model.pkg.my_model2"].relation_name == "`db1_alias`.`schema`.`table`"
+
+    # No alias for db2
+    assert result["model.pkg.my_model3"].database == "db2"
+    assert result["model.pkg.my_model3"].relation_name == '"db2"."schema"."table"'
+
+    # Null database/relation_name handled
+    assert result["model.pkg.my_model4"].database is None
+    assert result["model.pkg.my_model4"].relation_name is None
+
+
+def test_transformer_can_add_nodes():
+    """A transformer can add new nodes to the dict."""
+    def add_node(nodes, context):
+        nodes["model.pkg.new"] = _make_node("new", "db1")
+        return nodes
+
+    nodes = {"model.pkg.a": _make_node("a")}
+    result = chain_transformers([add_node])(nodes, _DUMMY_CTX)
+    assert "model.pkg.new" in result
+    assert len(result) == 2
+
+
+def test_transformer_can_remove_nodes():
+    """A transformer can remove nodes from the dict."""
+    def remove_node(nodes, context):
+        return {k: v for k, v in nodes.items() if v.name != "to_remove"}
+
+    nodes = {
+        "model.pkg.keep": _make_node("keep"),
+        "model.pkg.to_remove": _make_node("to_remove"),
+    }
+    result = chain_transformers([remove_node])(nodes, _DUMMY_CTX)
+    assert "model.pkg.keep" in result
+    assert "model.pkg.to_remove" not in result


### PR DESCRIPTION
## Summary

- Adds a `node_transformers` config option to `ManifestReference` that accepts a list of dotted Python import paths to user-defined callables
- Each transformer receives the selected `ManifestNode` dict and a `TransformerContext` (manifest name, reference name, raw manifest), and returns a potentially modified nodes dict
- Transformers are chained in list order, applied after node selection and before `excluded_packages` filtering

## Motivation

dbt-loom currently has no way for users to customize how upstream manifest nodes are processed after loading. Use cases like database aliasing, schema rewriting, or node filtering require changes to dbt-loom itself. This PR introduces a generic hook point so users can apply arbitrary transformations without forking the project.

## Example usage

```python
# my_transforms.py
def rewrite_databases(nodes, context):
    alias_map = {"upstream_db": "downstream_db"}
    for node in nodes.values():
        if node.database and node.database in alias_map:
            original = node.database
            alias = alias_map[original]
            node.database = alias
            if node.relation_name:
                node.relation_name = node.relation_name.replace(original, alias, 1)
    return nodes
```

```yml
# dbt_loom.config.yml
manifests:
  - name: revenue
    type: file
    config:
      path: ../revenue/target/manifest.json
    node_transformers:
      - "my_transforms.rewrite_databases"
```