### PR TITLE
Add Dagster Cloud Manifest Loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,13 @@ flowchart LR
     object_storage[Object Storage]:::background
     data_warehouse_storage[Data Warehouse Storage]:::background
     discovery_api[dbt-core Hosting Providers]:::background
+    orchestration[Orchestration Platforms]:::background
 
     discovery_api --> proprietary_plugin
     files --> proprietary_plugin
     object_storage --> proprietary_plugin
     data_warehouse_storage --> proprietary_plugin
+    orchestration --> proprietary_plugin
     proprietary_plugin --> dbt_runtime
   end
 
@@ -48,6 +50,8 @@ dbt-loom currently supports obtaining model definitions from:
 - Database Warehouse Storage
   - Snowflake stages
   - Databricks Volume, DBFS, and Workspace locations
+- Orchestration Platforms
+  - Dagster Cloud
 
 ## Getting Started
 
@@ -206,6 +210,52 @@ manifests:
       stage: stage_name # Stage name, can include Database/Schema
       stage_path: path/to/dbt/manifest.json # Path to manifest file in the stage
 ```
+
+#### Orchestration Platforms
+
+`dbt-loom` supports fetching manifest artifacts from orchestration platforms
+that run dbt and store build artifacts.
+
+```yaml
+manifests:
+  - name: dagster_cloud_project
+    type: dagster_cloud
+    config:
+      # Your Dagster Cloud organization name.
+      organization: <YOUR DAGSTER CLOUD ORGANIZATION>
+
+      # The artifact key for your manifest file in Dagster Cloud.
+      key: <YOUR ARTIFACT KEY>
+```
+
+The `key` value is derived from the state path of your packaged dbt project in
+the production deployment. For example, given the following Dagster dbt component
+config:
+
+```yaml
+attributes:
+  project:
+    project_dir: "{{ project_root }}/dbt"
+    packaged_project_dir: "{{ project_root }}/src/dbt-project"
+    state_path: state
+```
+
+Where `{{ project_root }}` resolves to your deployment's project root (commonly
+`/opt/dagster/app` for Docker deployments), the artifact key would be:
+
+```
+/opt/dagster/app/src/dbt-project/state/manifest.json
+```
+
+Authentication is resolved in the following order:
+1. The `DAGSTER_CLOUD_API_TOKEN` environment variable
+2. The `dg` CLI config (set up via `dg plus login`)
+
+> [!NOTE]
+> Your Dagster production deployment must upload the dbt `manifest.json` as an
+> artifact to Dagster Cloud for dbt-loom to fetch it. See the
+> [Dagster dbt integration reference](https://docs.dagster.io/integrations/libraries/dbt/reference#leveraging-dbt-defer-with-branch-deployments)
+> for details on managing dbt state in Dagster deployments.
 
 ### Using environment variables
 

--- a/dbt_loom/clients/dagster_cloud.py
+++ b/dbt_loom/clients/dagster_cloud.py
@@ -1,0 +1,83 @@
+import gzip
+import json
+import os
+from io import BytesIO
+from typing import Any, Dict, Optional
+from dagster_shared.plus.config import DagsterPlusCliConfig
+from pydantic import BaseModel
+import requests
+
+from dbt_loom.logging import fire_event
+
+
+class DagsterCloudReferenceConfig(BaseModel):
+    """Configuration for a Dagster Cloud reference."""
+
+    organization: str
+    key: str
+
+
+class DagsterCloudClient:
+    """API Client for Dagster Cloud. Fetches manifest artifacts from Dagster Cloud."""
+
+    def __init__(
+        self,
+        organization: str,
+        key: str,
+        token: Optional[str] = None,
+    ) -> None:
+        resolved_token = token or self._get_user_token_from_config()
+        if resolved_token is None:
+            raise Exception(
+                "A Dagster Cloud API token must be provided to dbt-loom when fetching "
+                "manifest data from Dagster Cloud. Please login to dagster cloud using "
+                "`dg plus login` or provide one via the `DAGSTER_CLOUD_API_TOKEN` "
+                "environment variable."
+            )
+
+        self.__token: str = resolved_token
+        self.organization = organization
+        self.key = key
+        self.base_url = "https://dagster.cloud"
+
+    def _get_user_token_from_config(self) -> Optional[str]:
+        env_value = os.environ.get("DAGSTER_CLOUD_API_TOKEN")
+        if env_value:
+            return env_value
+
+        if DagsterPlusCliConfig.exists():
+            try:
+                config = DagsterPlusCliConfig.get()
+                return config.user_token
+            except Exception:
+                pass
+
+        return None
+
+    def load_manifest(self) -> Dict[str, Any]:
+        """Load a manifest from Dagster Cloud artifact storage.
+
+        1. POST to gen_artifact_get with the artifact key to get a presigned URL.
+        2. GET the presigned URL to fetch the manifest JSON.
+        """
+        url = f"{self.base_url}/{self.organization}/gen_artifact_get"
+        fire_event(msg=f"Requesting artifact URL from {url}")
+
+        response = requests.post(
+            url,
+            json={"key": self.key},
+            headers={"Dagster-Cloud-Api-Token": self.__token},
+        )
+        response.raise_for_status()
+
+        presigned_url = response.json()["url"]
+        fire_event(msg="Fetching manifest from presigned URL")
+
+        manifest_response = requests.get(presigned_url)
+        manifest_response.raise_for_status()
+
+        if manifest_response.headers.get("Content-Encoding") == "gzip":
+            with gzip.GzipFile(fileobj=BytesIO(manifest_response.content)) as gz_file:
+                return json.load(gz_file)
+
+        return manifest_response.json()

--- a/dbt_loom/clients/dagster_cloud.py
+++ b/dbt_loom/clients/dagster_cloud.py
@@ -60,11 +60,10 @@ class DagsterCloudClient:
         1. POST to gen_artifact_get with the artifact key to get a presigned URL.
         2. GET the presigned URL to fetch the manifest JSON.
         """
-        url = f"{self.base_url}/{self.organization}/gen_artifact_get"
-        fire_event(msg=f"Requesting artifact URL from {url}")
+        fire_event(msg=f"Requesting manifest from Dagster Cloud ({self.base_url}/{self.organization})")
 
         response = requests.post(
-            url,
+            f"{self.base_url}/{self.organization}/gen_artifact_get",
             json={"key": self.key},
             headers={"Dagster-Cloud-Api-Token": self.__token},
         )

--- a/dbt_loom/config.py
+++ b/dbt_loom/config.py
@@ -12,6 +12,7 @@ from dbt_loom.clients.gcs import GCSReferenceConfig
 from dbt_loom.clients.paradime import ParadimeReferenceConfig
 from dbt_loom.clients.s3 import S3ReferenceConfig
 from dbt_loom.clients.snowflake_stage import SnowflakeReferenceConfig
+from dbt_loom.clients.dagster_cloud import DagsterCloudReferenceConfig
 from dbt_loom.clients.dbx import DatabricksReferenceConfig
 
 
@@ -26,6 +27,7 @@ class ManifestReferenceType(str, Enum):
     azure = "azure"
     snowflake = "snowflake"
     databricks = "databricks"
+    dagster_cloud = "dagster_cloud"
 
 
 class FileReferenceConfig(BaseModel):
@@ -58,6 +60,7 @@ _TYPE_TO_CONFIG = {
     ManifestReferenceType.azure: AzureReferenceConfig,
     ManifestReferenceType.snowflake: SnowflakeReferenceConfig,
     ManifestReferenceType.databricks: DatabricksReferenceConfig,
+    ManifestReferenceType.dagster_cloud: DagsterCloudReferenceConfig,
 }
 
 
@@ -75,6 +78,7 @@ class ManifestReference(BaseModel):
         AzureReferenceConfig,
         SnowflakeReferenceConfig,
         DatabricksReferenceConfig,
+        DagsterCloudReferenceConfig,
     ]
     excluded_packages: List[str] = Field(default_factory=list)
     optional: bool = False

--- a/dbt_loom/manifests.py
+++ b/dbt_loom/manifests.py
@@ -18,6 +18,10 @@ except ModuleNotFoundError:
     from dbt.node_types import NodeType  # type: ignore
 
 from dbt_loom.clients.az_blob import AzureClient, AzureReferenceConfig
+from dbt_loom.clients.dagster_cloud import (
+    DagsterCloudClient,
+    DagsterCloudReferenceConfig,
+)
 from dbt_loom.clients.dbt_cloud import DbtCloud, DbtCloudReferenceConfig
 from dbt_loom.clients.paradime import ParadimeClient, ParadimeReferenceConfig
 from dbt_loom.clients.gcs import GCSClient, GCSReferenceConfig
@@ -113,6 +117,7 @@ class ManifestLoader:
             ManifestReferenceType.snowflake: self.load_from_snowflake,
             ManifestReferenceType.paradime: self.load_from_paradime,
             ManifestReferenceType.databricks: self.load_from_databricks,
+            ManifestReferenceType.dagster_cloud: self.load_from_dagster_cloud,
         }
 
     @staticmethod
@@ -247,6 +252,15 @@ class ManifestLoader:
         """Load a manifest dictionary from Databricks."""
         databricks_client = DatabricksClient(path=config.path)
         return databricks_client.load_manifest()
+
+    @staticmethod
+    def load_from_dagster_cloud(config: DagsterCloudReferenceConfig) -> Dict:
+        """Load a manifest dictionary from Dagster Cloud."""
+        client = DagsterCloudClient(
+            organization=config.organization,
+            key=config.key,
+        )
+        return client.load_manifest()
 
     def load(self, manifest_reference: ManifestReference) -> Optional[Dict]:
         """Load a manifest dictionary based on a ManifestReference input."""

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -57,6 +57,16 @@ tests with:
 pytest tests/
 ```
 
+To run the tests againt all supported dbt-core and python versions, you can run the tests using [act](https://github.com/nektos/act) CLI:
+```bash
+act pull_request \
+  -W .github/workflows/test.yml \
+  --container-architecture linux/amd64 \
+  --env DOCKER_HOST=unix:///var/run/docker.sock \
+  --env TC_HOST=host.docker.internal \
+  --container-options "--add-host=host.docker.internal:host-gateway"
+```
+
 ### Documentation
 
 Contributions to documentation are always welcome. If you see something that can be improved or needs clarification, feel free to make changes.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -158,3 +158,47 @@ manifests:
     config:
       path: <WORKSPACE, VOLUME, OR DBFS PATH TO MANIFEST FILE>
 ```
+
+## Using Dagster Cloud as an artifact source
+
+You can use dbt-loom to fetch manifest artifacts from Dagster Cloud by setting up
+a `dagster_cloud` manifest in your `dbt-loom` config. Authentication is resolved
+automatically from the `DAGSTER_CLOUD_API_TOKEN` environment variable or the
+`dg` CLI config (set up via `dg plus login`).
+
+```yaml
+manifests:
+  - name: project_name
+    type: dagster_cloud
+    config:
+      organization: <YOUR DAGSTER CLOUD ORGANIZATION>
+      # Your Dagster Cloud organization name.
+
+      key: <YOUR ARTIFACT KEY>
+      # The artifact key for your manifest file in Dagster Cloud.
+```
+
+The `key` value is derived from the state path of your packaged dbt project in
+the production deployment. For example, given the following Dagster dbt component
+config:
+
+```yaml
+attributes:
+  project:
+    project_dir: "{{ project_root }}/dbt"
+    packaged_project_dir: "{{ project_root }}/src/dbt-project"
+    state_path: state
+```
+
+Where `{{ project_root }}` resolves to your deployment's project root (commonly
+`/opt/dagster/app` for Docker deployments), the artifact key would be:
+
+```
+/opt/dagster/app/src/dbt-project/state/manifest.json
+```
+
+> [!NOTE]
+> Your Dagster production deployment must upload the dbt `manifest.json` as an
+> artifact to Dagster Cloud for dbt-loom to fetch it. See the
+> [Dagster dbt integration reference](https://docs.dagster.io/integrations/libraries/dbt/reference#leveraging-dbt-defer-with-branch-deployments)
+> for details on managing dbt state in Dagster deployments.

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,11 +14,13 @@ flowchart LR
     object_storage[Object Storage]:::background
     data_warehouse_storage[Data Warehouse Storage]:::background
     discovery_api[dbt-core Hosting Providers]:::background
+    orchestration[Orchestration Platforms]:::background
 
     discovery_api --> proprietary_plugin
     files --> proprietary_plugin
     object_storage --> proprietary_plugin
     data_warehouse_storage --> proprietary_plugin
+    orchestration --> proprietary_plugin
     proprietary_plugin --> dbt_runtime
   end
 
@@ -40,6 +42,8 @@ dbt-loom currently supports obtaining model definitions from:
 - Database Warehouse Storage
   - Snowflake stages
   - Databricks Volume, DBFS, and Workspace locations
+- Orchestration Platforms
+  - Dagster Cloud
 
 ## How does it work?
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "types-networkx>=3.2.1.20240313,<4",
     "paradime-io>=4.11.0,<5",
     "google-auth>=2.40.3",
+    "dagster-shared>=1.12.14",
 ]
 
 [project.optional-dependencies]
@@ -31,6 +32,7 @@ dev = [
     "pre-commit>=3.6.0,<4",
     "mypy>=1.8.0,<2",
     "types-requests>=2.31.0.6",
+    "responses>=0.26.0",
 ]
 docs = ["mkdocs-material>=9.5.45,<10", "mike>=2.1.3,<3"]
 

--- a/tests/test_manifest_loaders.py
+++ b/tests/test_manifest_loaders.py
@@ -5,12 +5,18 @@ from typing import Dict, Generator, Tuple
 from urllib.parse import urlparse
 
 import pytest
+import responses
 from dbt_loom.config import (
     FileReferenceConfig,
     ManifestReference,
     ManifestReferenceType,
     LoomConfigurationError,
 )
+from dbt_loom.clients.dagster_cloud import (
+    DagsterCloudClient,
+    DagsterCloudReferenceConfig,
+)
+from dagster_shared.plus.config import DagsterPlusCliConfig
 from dbt_loom.clients.dbx import DatabricksReferenceConfig
 from dbt_loom.manifests import ManifestLoader, UnknownManifestPathType
 
@@ -152,3 +158,98 @@ def test_manifest_reference_resolves_file_config():
         config={"path": "manifest.json"},
     )
     assert isinstance(ref.config, FileReferenceConfig)
+
+
+class TestDagsterCloudManifestLoader:
+    """Tests for the Dagster Cloud manifest loader."""
+
+    @responses.activate
+    def test_load_manifest(self):
+        """Test that DagsterCloudClient can load a manifest via the two-step API flow."""
+        manifest_content = {"nodes": {"model.my_project.my_model": {}}}
+        presigned_url = "https://storage.example.com/presigned/manifest.json"
+
+        responses.post(
+            "https://dagster.cloud/my-org/gen_artifact_get",
+            json={"url": presigned_url},
+            status=200,
+        )
+        responses.get(
+            presigned_url,
+            json=manifest_content,
+            status=200,
+        )
+
+        client = DagsterCloudClient(
+            organization="my-org",
+            key="dagster/manifest.json",
+            token="test-token",
+        )
+        result = client.load_manifest()
+        assert result == manifest_content
+
+    def test_missing_token(self, monkeypatch):
+        """Test that DagsterCloudClient raises when no token is available."""
+        monkeypatch.delenv("DAGSTER_CLOUD_API_TOKEN", raising=False)
+        monkeypatch.setattr(DagsterPlusCliConfig, "exists", staticmethod(lambda: False))
+
+        with pytest.raises(Exception, match="dg plus login"):
+            DagsterCloudClient(
+                organization="my-org",
+                key="dagster/manifest.json",
+            )
+
+    def test_token_from_env_var(self, monkeypatch):
+        """Test that DagsterCloudClient falls back to the DAGSTER_CLOUD_API_TOKEN env var."""
+        monkeypatch.setenv("DAGSTER_CLOUD_API_TOKEN", "env-token")
+        monkeypatch.setattr(DagsterPlusCliConfig, "exists", staticmethod(lambda: False))
+
+        client = DagsterCloudClient(
+            organization="my-org",
+            key="dagster/manifest.json",
+        )
+        assert client._DagsterCloudClient__token == "env-token"
+
+    def test_token_from_cli_config(self, monkeypatch):
+        """Test that DagsterCloudClient falls back to DagsterPlusCliConfig."""
+        monkeypatch.delenv("DAGSTER_CLOUD_API_TOKEN", raising=False)
+        monkeypatch.setattr(DagsterPlusCliConfig, "exists", staticmethod(lambda: True))
+        monkeypatch.setattr(
+            DagsterPlusCliConfig,
+            "get",
+            classmethod(lambda cls: DagsterPlusCliConfig(user_token="cli-token")),
+        )
+
+        client = DagsterCloudClient(
+            organization="my-org",
+            key="dagster/manifest.json",
+        )
+        assert client._DagsterCloudClient__token == "cli-token"
+
+    def test_explicit_token_takes_precedence(self, monkeypatch):
+        """Test that an explicit token takes precedence over env var and CLI config."""
+        monkeypatch.setenv("DAGSTER_CLOUD_API_TOKEN", "env-token")
+        monkeypatch.setattr(DagsterPlusCliConfig, "exists", staticmethod(lambda: True))
+        monkeypatch.setattr(
+            DagsterPlusCliConfig,
+            "get",
+            classmethod(lambda cls: DagsterPlusCliConfig(user_token="cli-token")),
+        )
+
+        client = DagsterCloudClient(
+            organization="my-org",
+            key="dagster/manifest.json",
+            token="explicit-token",
+        )
+        assert client._DagsterCloudClient__token == "explicit-token"
+
+    def test_config_resolution(self):
+        """Verify that type=dagster_cloud produces DagsterCloudReferenceConfig."""
+        ref = ManifestReference(
+            name="test_dagster",
+            type=ManifestReferenceType.dagster_cloud,
+            config={"organization": "my-org", "key": "dagster/manifest.json"},
+        )
+        assert isinstance(ref.config, DagsterCloudReferenceConfig)
+        assert ref.config.organization == "my-org"
+        assert ref.config.key == "dagster/manifest.json"

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 3
 requires-python = ">=3.9, <4.0"
 resolution-markers = [
     "python_full_version < '3.10'",
@@ -400,6 +401,23 @@ wheels = [
 ]
 
 [[package]]
+name = "dagster-shared"
+version = "1.12.14"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "platformdirs" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "tomlkit" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/07/b7805cc1994b4a40a660bd8b73970005f99b59c9616f83551f9a7a76a438/dagster_shared-1.12.14.tar.gz", hash = "sha256:954f3065d8e477880176573d6aaf034fc099cbe2679472717cdbe29071b902ce", size = 78638, upload-time = "2026-02-05T21:28:31.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/c7/40bb84eef417f03f66854ecc478870c0a041b7d1898e72244ac583f34361/dagster_shared-1.12.14-py3-none-any.whl", hash = "sha256:c6784ac03f80db252a40929c5f061138446cf4ef76884697c07160ad0184626a", size = 91894, upload-time = "2026-02-05T21:28:30.027Z" },
+]
+
+[[package]]
 name = "dbt-adapters"
 version = "1.16.5"
 source = { registry = "https://pypi.org/simple" }
@@ -520,6 +538,7 @@ dependencies = [
     { name = "azure-identity" },
     { name = "azure-storage-blob" },
     { name = "boto3" },
+    { name = "dagster-shared" },
     { name = "dbt-core" },
     { name = "google-auth" },
     { name = "google-cloud-storage" },
@@ -537,6 +556,7 @@ dev = [
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pytest" },
+    { name = "responses" },
     { name = "ruff" },
     { name = "types-requests" },
 ]
@@ -550,6 +570,7 @@ requires-dist = [
     { name = "azure-identity", specifier = ">=1.15.0,<2" },
     { name = "azure-storage-blob", specifier = ">=12.19.0,<13" },
     { name = "boto3", specifier = ">=1.28.84,<2" },
+    { name = "dagster-shared", specifier = ">=1.12.14" },
     { name = "dbt-core", specifier = ">=1.6.0,<1.12.0" },
     { name = "google-auth", specifier = ">=2.40.3" },
     { name = "google-cloud-storage", specifier = ">=2.13.0,<4" },
@@ -568,6 +589,7 @@ dev = [
     { name = "mypy", specifier = ">=1.8.0,<2" },
     { name = "pre-commit", specifier = ">=3.6.0,<4" },
     { name = "pytest", specifier = ">=7.4.0,<8" },
+    { name = "responses", specifier = ">=0.26.0" },
     { name = "ruff", specifier = ">=0.3.0,<0.12" },
     { name = "types-requests", specifier = ">=2.31.0.6" },
 ]
@@ -1889,6 +1911,20 @@ wheels = [
 ]
 
 [[package]]
+name = "responses"
+version = "0.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/b4/b7e040379838cc71bf5aabdb26998dfbe5ee73904c92c1c161faf5de8866/responses-0.26.0.tar.gz", hash = "sha256:c7f6923e6343ef3682816ba421c006626777893cb0d5e1434f674b649bac9eb4", size = 81303, upload-time = "2026-02-19T14:38:05.574Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/04/7f73d05b556da048923e31a0cc878f03be7c5425ed1f268082255c75d872/responses-0.26.0-py3-none-any.whl", hash = "sha256:03ec4409088cd5c66b71ecbbbd27fe2c58ddfad801c66203457b3e6a04868c37", size = 35099, upload-time = "2026-02-19T14:38:03.847Z" },
+]
+
+[[package]]
 name = "rich"
 version = "14.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2198,6 +2234,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/b9/1ed31d167be802da0fc95020d04cd27b7d7065cc6fbefdd2f9186f60d7bd/tomli-2.2.1-cp313-cp313-win32.whl", hash = "sha256:d3f5614314d758649ab2ab3a62d4f2004c825922f9e370b29416484086b264ec", size = 98724, upload-time = "2024-11-27T22:38:32.837Z" },
     { url = "https://files.pythonhosted.org/packages/c7/32/b0963458706accd9afcfeb867c0f9175a741bf7b19cd424230714d722198/tomli-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:a38aa0308e754b0e3c67e344754dff64999ff9b513e691d0e786265c93583c69", size = 109383, upload-time = "2024-11-27T22:38:34.455Z" },
     { url = "https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc", size = 14257, upload-time = "2024-11-27T22:38:35.385Z" },
+]
+
+[[package]]
+name = "tomlkit"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/af/14b24e41977adb296d6bd1fb59402cf7d60ce364f90c890bd2ec65c43b5a/tomlkit-0.14.0.tar.gz", hash = "sha256:cf00efca415dbd57575befb1f6634c4f42d2d87dbba376128adb42c121b87064", size = 187167, upload-time = "2026-01-13T01:14:53.304Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/11/87d6d29fb5d237229d67973a6c9e06e048f01cf4994dee194ab0ea841814/tomlkit-0.14.0-py3-none-any.whl", hash = "sha256:592064ed85b40fa213469f81ac584f67a4f2992509a7c3ea2d632208623a3680", size = 39310, upload-time = "2026-01-13T01:14:51.965Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -2,9 +2,9 @@ version = 1
 revision = 3
 requires-python = ">=3.9, <4.0"
 resolution-markers = [
-    "python_full_version < '3.10'",
-    "python_full_version >= '3.10' and python_full_version < '3.13'",
     "python_full_version >= '3.13'",
+    "python_full_version >= '3.10' and python_full_version < '3.13'",
+    "python_full_version < '3.10'",
 ]
 
 [[package]]
@@ -419,44 +419,100 @@ wheels = [
 
 [[package]]
 name = "dbt-adapters"
-version = "1.16.5"
+version = "1.17.3"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "agate" },
-    { name = "dbt-common" },
-    { name = "dbt-protos" },
-    { name = "mashumaro", extra = ["msgpack"] },
-    { name = "protobuf" },
-    { name = "pytz" },
-    { name = "typing-extensions" },
+resolution-markers = [
+    "python_full_version < '3.10'",
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c1/ba/0163db84fa6a4339066ce7fee59d83992451beb77370a91989c3db9d499e/dbt_adapters-1.16.5.tar.gz", hash = "sha256:3803c60bcf16bc1cbfdec1b20cee290072d861edbe93b97b3e92a935c57e21d3", size = 130578, upload-time = "2025-08-19T13:52:04.616Z" }
+dependencies = [
+    { name = "agate", marker = "python_full_version < '3.10'" },
+    { name = "dbt-common", version = "1.34.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "dbt-protos", marker = "python_full_version < '3.10'" },
+    { name = "mashumaro", extra = ["msgpack"], marker = "python_full_version < '3.10'" },
+    { name = "protobuf", marker = "python_full_version < '3.10'" },
+    { name = "pytz", marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/88/d9/5d585d39d657e191af8f4fd30a5e1b3cc2b7182493ceaa75c94c9bc50909/dbt_adapters-1.17.3.tar.gz", hash = "sha256:8f3c2ea081444033ed3146aea85c21175f868c1f2dd262e7caab19f78bcf25cc", size = 133250, upload-time = "2025-10-20T15:57:04.114Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/2c/cc5b0d92925db81b6d0fe18bdec904600ba43060299dd36cb62edc80e34a/dbt_adapters-1.16.5-py3-none-any.whl", hash = "sha256:f9128745a0592e0047b37acc99deb12a7aa250f8780969e998b09f7219c03d8c", size = 167096, upload-time = "2025-08-19T13:52:03.136Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ef/c6dc3f066cdd6e2cb6a3a645704eddde0ec240e2a4feb1c499824d35884e/dbt_adapters-1.17.3-py3-none-any.whl", hash = "sha256:7421f13edbb90e29c114cf14bda6b9c29d708b34a3c912f6668dd4414b0650e4", size = 170317, upload-time = "2025-10-20T15:57:02.798Z" },
+]
+
+[[package]]
+name = "dbt-adapters"
+version = "1.22.10"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13'",
+    "python_full_version >= '3.10' and python_full_version < '3.13'",
+]
+dependencies = [
+    { name = "agate", marker = "python_full_version >= '3.10'" },
+    { name = "dbt-common", version = "1.37.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "dbt-protos", marker = "python_full_version >= '3.10'" },
+    { name = "mashumaro", extra = ["msgpack"], marker = "python_full_version >= '3.10'" },
+    { name = "protobuf", marker = "python_full_version >= '3.10'" },
+    { name = "pytz", marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/f6/a74ae2c203b5a475a2d8866a2ccf7deb253e0f1cbaee86b6faf1562503e2/dbt_adapters-1.22.10.tar.gz", hash = "sha256:28fca9f9c2f310706ce02c8f7b0f297edca14d6bd97ad7928aac55af4ce2972f", size = 138306, upload-time = "2026-03-30T16:57:29.106Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/9b/7913d4780962e323956d10c21328af5fcf85d00ab273eb7e808d8ec19336/dbt_adapters-1.22.10-py3-none-any.whl", hash = "sha256:9217a2f8dd35425cafc9093dae70ea12b4b8fc414e3abce8a44d44d5c2fff563", size = 173738, upload-time = "2026-03-30T16:57:27.636Z" },
 ]
 
 [[package]]
 name = "dbt-common"
-version = "1.34.1"
+version = "1.34.2"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "agate" },
-    { name = "colorama" },
-    { name = "dbt-protos" },
-    { name = "deepdiff" },
-    { name = "isodate" },
-    { name = "jinja2" },
-    { name = "jsonschema" },
-    { name = "mashumaro", extra = ["msgpack"] },
-    { name = "pathspec" },
-    { name = "protobuf" },
-    { name = "python-dateutil" },
-    { name = "requests" },
-    { name = "typing-extensions" },
+resolution-markers = [
+    "python_full_version < '3.10'",
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5b/33/49a01b0fb2721ffa2d8c7587ffea4475f21bc89c5432645be9201c570c8a/dbt_common-1.34.1.tar.gz", hash = "sha256:40872e9def1106b5a7eeb4e0e4bb3198dd2e0d51233295297cc40c564654ce30", size = 85457, upload-time = "2026-01-06T20:12:57.834Z" }
+dependencies = [
+    { name = "agate", marker = "python_full_version < '3.10'" },
+    { name = "colorama", marker = "python_full_version < '3.10'" },
+    { name = "dbt-protos", marker = "python_full_version < '3.10'" },
+    { name = "deepdiff", marker = "python_full_version < '3.10'" },
+    { name = "isodate", marker = "python_full_version < '3.10'" },
+    { name = "jinja2", marker = "python_full_version < '3.10'" },
+    { name = "jsonschema", marker = "python_full_version < '3.10'" },
+    { name = "mashumaro", extra = ["msgpack"], marker = "python_full_version < '3.10'" },
+    { name = "pathspec", marker = "python_full_version < '3.10'" },
+    { name = "protobuf", marker = "python_full_version < '3.10'" },
+    { name = "python-dateutil", marker = "python_full_version < '3.10'" },
+    { name = "requests", marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/eb/86debdf5a41b3fc1a121fd06baaa229466cf00c8c973773e41e38ec6ed80/dbt_common-1.34.2.tar.gz", hash = "sha256:0c8a27f2005f5b44c0d786d2c9825103c4dbeca8e5815739654cc4ea6367e242", size = 85605, upload-time = "2026-03-03T01:28:13.945Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/6a/5efb9ba6c5f761958e585c45242e241284c7a49e2881b387cc4594a715dd/dbt_common-1.34.1-py3-none-any.whl", hash = "sha256:a4b18dbe147b169f8ccecbddf9a5b5fd0f5bd805e32f65071dc614e3294cd803", size = 87390, upload-time = "2026-01-06T20:12:56.413Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/49/19d607f59d7c520de1ded3cc748496286d9ffefde4cf6ed9cb12760fefb6/dbt_common-1.34.2-py3-none-any.whl", hash = "sha256:e0d0d2412710e103e829a0d134359f37e9a14685955910de8344258b8110848c", size = 87459, upload-time = "2026-03-03T01:28:12.345Z" },
+]
+
+[[package]]
+name = "dbt-common"
+version = "1.37.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13'",
+    "python_full_version >= '3.10' and python_full_version < '3.13'",
+]
+dependencies = [
+    { name = "agate", marker = "python_full_version >= '3.10'" },
+    { name = "colorama", marker = "python_full_version >= '3.10'" },
+    { name = "dbt-protos", marker = "python_full_version >= '3.10'" },
+    { name = "deepdiff", marker = "python_full_version >= '3.10'" },
+    { name = "isodate", marker = "python_full_version >= '3.10'" },
+    { name = "jinja2", marker = "python_full_version >= '3.10'" },
+    { name = "jsonschema", marker = "python_full_version >= '3.10'" },
+    { name = "mashumaro", extra = ["msgpack"], marker = "python_full_version >= '3.10'" },
+    { name = "pathspec", marker = "python_full_version >= '3.10'" },
+    { name = "protobuf", marker = "python_full_version >= '3.10'" },
+    { name = "python-dateutil", marker = "python_full_version >= '3.10'" },
+    { name = "requests", marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/3a/c95078b7ebb87795551f73fd58e5ddbcf7f75b478e9b50ab72fe2939baf0/dbt_common-1.37.3.tar.gz", hash = "sha256:f99304cf93f549c09d302eb61d9b280748bbe24e2245e214189ea08b41196ec3", size = 86217, upload-time = "2026-03-02T17:26:34.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/7e/629351d21ffa1b51a893334faf8c497f0c34f4da3cece9b24d7a5af29d90/dbt_common-1.37.3-py3-none-any.whl", hash = "sha256:e11b81903107d9f254d0ec7ac14b2bcf6d531e46456cbc7881fdbfeb9bbd8eec", size = 87733, upload-time = "2026-03-02T17:26:31.248Z" },
 ]
 
 [[package]]
@@ -467,8 +523,10 @@ dependencies = [
     { name = "agate" },
     { name = "click" },
     { name = "daff" },
-    { name = "dbt-adapters" },
-    { name = "dbt-common" },
+    { name = "dbt-adapters", version = "1.17.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "dbt-adapters", version = "1.22.10", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "dbt-common", version = "1.34.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "dbt-common", version = "1.37.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "dbt-extractor" },
     { name = "dbt-protos" },
     { name = "dbt-semantic-interfaces" },
@@ -497,8 +555,10 @@ name = "dbt-duckdb"
 version = "1.9.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "dbt-adapters" },
-    { name = "dbt-common" },
+    { name = "dbt-adapters", version = "1.17.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "dbt-adapters", version = "1.22.10", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "dbt-common", version = "1.34.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "dbt-common", version = "1.37.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "dbt-core" },
     { name = "duckdb" },
 ]


### PR DESCRIPTION
## Summary

Closes #165

- Add `dagster_cloud` manifest type that fetches `manifest.json` directly from Dagster Cloud's organization artifact storage, using the same API that `dagster-cloud ci dagster-dbt project manage-state` uses
- Authentication is resolved from the `DAGSTER_CLOUD_API_TOKEN` environment variable or the `dg` CLI config (`dg plus login`)
- Add documentation for the new loader in README, getting-started guide, and docs index

## Changes

- `dbt_loom/clients/dagster_cloud.py` — New `DagsterCloudClient` and `DagsterCloudReferenceConfig` classes
- `dbt_loom/config.py` — Add `dagster_cloud` to `ManifestReferenceType` enum and config union
- `dbt_loom/manifests.py` — Wire up Dagster Cloud loading in `ManifestLoader`
- `pyproject.toml` / `uv.lock` — Add `dagster-shared` dependency
- `tests/test_manifest_loaders.py` — Unit tests for the client and config
- `README.md`, `docs/getting-started.md`, `docs/index.md` — Documentation for the new source type

## Test plan

- [x] `uv run pytest tests/test_manifest_loaders.py` passes
- [x] Manual test against a Dagster Cloud organization with a stored dbt manifest artifact