### PR TITLE
fix: only patch ref protection when a dbt-loom config is present

### DIFF
--- a/dbt_loom/__init__.py
+++ b/dbt_loom/__init__.py
@@ -131,7 +131,8 @@ class dbtLoom(dbtPlugin):
         self.config: Optional[dbtLoomConfig] = self.read_config(configuration_path)
         self.models: Dict[str, LoomModelNodeArgs] = {}
 
-        self._patch_ref_protection()
+        if self.config is not None:
+            self._patch_ref_protection()
 
         if not self.config or (self.config and not self.config.enable_telemetry):
             self._patch_plugin_telemetry()


### PR DESCRIPTION
## Summary

Fixes #173.

When dbt-loom is installed as a transitive dependency but no `dbt_loom.config.yml` exists, `_patch_ref_protection()` was still being applied unconditionally. The shims in `shims.py` are more permissive than dbt's originals for `is_invalid_private_ref`:

- A singular test with no `{{ config(group=...) }}` block has `node.group = None`, so the first condition in the shim is always `False`.
- If the nodes share a package, the `restrict_access` condition is also `False`.
- The shim returns `False` (no error) where dbt's original would return `True`.

The existing `if self.config is not None` guard inside `dependency_wrapper` doesn't help — the wrapped function still calls the weaker shim once the patch has been applied.

## Fix

Guard `_patch_ref_protection()` on `self.config is not None`. When no config file exists, dbt-loom isn't being used for cross-project manifest injection, so there's no reason to weaken dbt's built-in access enforcement.

```python
if self.config is not None:
    self._patch_ref_protection()
```

## Test plan

- [x] Existing test suite still passes (`pytest tests/`)
- [x] Confirmed the bug reproduces on `main` in a project where dbt-loom is a transitive dep with no config file
- [x] Confirmed Z002 is now raised correctly after the fix
