### PR TITLE
Fix: skip self-owned nodes to prevent stale re-injection in circular loom topologies

### DIFF
--- a/dbt_loom/__init__.py
+++ b/dbt_loom/__init__.py
@@ -105,6 +105,7 @@ def merge_loom_nodes(
     existing_nodes: Dict[str, LoomModelNodeArgs],
     new_nodes: Dict[str, LoomModelNodeArgs],
     manifest_name: str,
+    root_project_name: Optional[str] = None,
 ) -> None:
     """Merge ``new_nodes`` from a manifest into ``existing_nodes`` in place.
 
@@ -112,8 +113,17 @@ def merge_loom_nodes(
     always be used. Transitive dependency nodes (from other packages) should
     only be added if not already provided by a previous, more authoritative
     manifest.
+
+    Nodes whose ``package_name`` matches ``root_project_name`` (the project
+    currently being compiled) are always skipped. Such nodes are stale
+    transitive copies that arrive via circular loom dependencies (e.g.
+    A -> B -> A); the local project is always authoritative for its own nodes,
+    and re-injecting an upstream snapshot can introduce references to disabled
+    or deleted models that are no longer in the local graph.
     """
     for key, value in new_nodes.items():
+        if root_project_name and value.package_name == root_project_name:
+            continue
         is_authoritative = value.package_name == manifest_name
         if is_authoritative or key not in existing_nodes:
             existing_nodes[key] = value
@@ -326,7 +336,10 @@ class dbtLoom(dbtPlugin):
 
             loom_nodes = convert_model_nodes_to_model_node_args(filtered_nodes)
 
-            merge_loom_nodes(self.models, loom_nodes, manifest_name)
+            merge_loom_nodes(
+                self.models, loom_nodes, manifest_name,
+                root_project_name=self.project_name,
+            )
 
     @dbt_hook
     def get_nodes(self) -> PluginNodes:

--- a/tests/test_node_deduplication.py
+++ b/tests/test_node_deduplication.py
@@ -27,18 +27,171 @@ def _make_node(unique_id, package_name, access="protected"):
     }
 
 
-def _merge_manifests(manifest_pairs):
+def _merge_manifests(manifest_pairs, root_project_name=None):
     """Simulate the initialize() merging logic from dbtLoom.
 
     Args:
         manifest_pairs: list of (manifest_dict, project_name) tuples in load order.
+        root_project_name: the name of the currently-compiling project, passed to
+            merge_loom_nodes to prevent self-injection.
     """
     models = {}
     for manifest, manifest_name in manifest_pairs:
         selected_nodes = identify_node_subgraph(manifest)
         loom_nodes = convert_model_nodes_to_model_node_args(selected_nodes)
-        merge_loom_nodes(models, loom_nodes, manifest_name)
+        merge_loom_nodes(models, loom_nodes, manifest_name, root_project_name=root_project_name)
     return models
+
+
+def test_authoritative_node_wins_over_transitive_copy():
+    """The owning manifest's public node should not be overwritten by a
+    protected transitive copy from a later manifest."""
+
+    uid = "model.project_a.shared_model"
+
+    models = _merge_manifests(
+        [
+            (
+                _make_manifest(
+                    "project_a", {uid: _make_node(uid, "project_a", access="public")}
+                ),
+                "project_a",
+            ),
+            (
+                _make_manifest(
+                    "project_b", {uid: _make_node(uid, "project_a", access="protected")}
+                ),
+                "project_b",
+            ),
+        ]
+    )
+
+    assert models[uid].access == "public"
+
+
+def test_authoritative_node_wins_regardless_of_load_order():
+    """Even if the transitive copy is loaded first, the authoritative manifest
+    should overwrite it."""
+
+    uid = "model.project_a.shared_model"
+
+    models = _merge_manifests(
+        [
+            (
+                _make_manifest(
+                    "project_b", {uid: _make_node(uid, "project_a", access="protected")}
+                ),
+                "project_b",
+            ),
+            (
+                _make_manifest(
+                    "project_a", {uid: _make_node(uid, "project_a", access="public")}
+                ),
+                "project_a",
+            ),
+        ]
+    )
+
+    assert models[uid].access == "public"
+
+
+def test_transitive_node_added_when_no_authoritative_source():
+    """Nodes from packages without their own manifest entry should still be
+    injected via the first manifest that provides them."""
+
+    uid = "model.project_c.some_model"
+
+    models = _merge_manifests(
+        [
+            (
+                _make_manifest(
+                    "project_a", {uid: _make_node(uid, "project_c", access="protected")}
+                ),
+                "project_a",
+            ),
+        ]
+    )
+
+    assert uid in models
+
+
+def test_first_transitive_copy_preserved_over_later_copies():
+    """When a non-authoritative node appears in multiple manifests, the first
+    loaded version should be kept."""
+
+    uid = "model.project_c.some_model"
+
+    models = _merge_manifests(
+        [
+            (
+                _make_manifest(
+                    "project_a", {uid: _make_node(uid, "project_c", access="public")}
+                ),
+                "project_a",
+            ),
+            (
+                _make_manifest(
+                    "project_b", {uid: _make_node(uid, "project_c", access="protected")}
+                ),
+                "project_b",
+            ),
+        ]
+    )
+
+    assert models[uid].access == "public"
+
+
+def test_root_project_nodes_are_not_reinjected():
+    """A stale transitive copy of the root project's own node must be dropped.
+
+    This guards against circular loom topologies (A -> B -> A) where the
+    upstream manifest carries an outdated snapshot of the root project's nodes.
+    Re-injecting such a snapshot can reference models that are now disabled or
+    deleted locally, causing 'not in the graph' compilation errors.
+    """
+    uid = "model.project_root.local_model"
+
+    models = _merge_manifests(
+        [
+            (
+                _make_manifest(
+                    "upstream",
+                    {uid: _make_node(uid, "project_root", access="public")},
+                ),
+                "upstream",
+            ),
+        ],
+        root_project_name="project_root",
+    )
+
+    assert uid not in models
+
+
+def test_non_root_nodes_still_injected_when_root_project_name_set():
+    """Setting root_project_name must not block injection of nodes from other
+    packages; only the root project's own nodes should be skipped."""
+    uid_root = "model.project_root.local_model"
+    uid_other = "model.upstream.shared_model"
+
+    models = _merge_manifests(
+        [
+            (
+                _make_manifest(
+                    "upstream",
+                    {
+                        uid_root: _make_node(uid_root, "project_root", access="public"),
+                        uid_other: _make_node(uid_other, "upstream", access="public"),
+                    },
+                ),
+                "upstream",
+            ),
+        ],
+        root_project_name="project_root",
+    )
+
+    assert uid_root not in models
+    assert uid_other in models
+
 
 
 def test_authoritative_node_wins_over_transitive_copy():


### PR DESCRIPTION
Hi @nicholasyager, I've encountered another issue related to circular topologies in loom for which I'm proposing a fix.

## Problem

In circular loom topologies (e.g. project A references project B, and project B also
references project A), the upstream manifest contains a snapshot of the root project's
own nodes captured at publication time. When the root project compiles, dbt-loom
injects those stale nodes back into the graph.

If any of those nodes reference models that have since been disabled or deleted locally,
dbt raises:

Compilation Error
  'model.project_a.some_model' depends on 'model.project_a.other_model'
  which is not in the graph!

The existing `merge_loom_nodes` deduplication logic (introduced in #164) does not
cover this case because the offending node's `package_name` matches the root project,
not a third package.

## Root Cause

`merge_loom_nodes` (and therefore `initialize()`) had no guard preventing a project
from injecting nodes that belong to its own package. A transitive copy arriving via
an upstream manifest is by definition stale; the local project is always authoritative
for its own nodes.

## Fix

Extended `merge_loom_nodes` with an optional `root_project_name` parameter. Any node
whose `package_name == root_project_name` is dropped before the authoritative-merge
step. `dbtLoom.initialize()` passes `self.project_name` for this parameter, so the
guard is applied automatically for every manifest that is loaded.

No changes to the public API — `root_project_name` defaults to `None`, preserving
existing behaviour when the parameter is not supplied.

## Tests Added

`tests/test_node_deduplication.py`:

- `test_root_project_nodes_are_not_reinjected` — a stale self-owned node arriving via
  an upstream manifest is not present in the merged result when `root_project_name` is
  set.
- `test_non_root_nodes_still_injected_when_root_project_name_set` — setting
  `root_project_name` does not prevent nodes from other packages from being injected.

All six tests in the file pass.