### PR TITLE
Feature/pass contract info

### DIFF
--- a/dbt_loom/__init__.py
+++ b/dbt_loom/__init__.py
@@ -34,18 +34,22 @@ class LoomModelNodeArgs(ModelNodeArgs):
     resource_type: NodeType = NodeType.Model
     group: Optional[str] = None
     event_time: Optional[str] = None
+    contract_info: dict = None
+    columns_info: dict = None
 
     def __init__(self, **kwargs):
         super().__init__(
             **{
                 key: value
                 for key, value in kwargs.items()
-                if key not in ("resource_type", "group", "config")
+                if key not in ("resource_type", "group", "config", "contract", "columns")
             }
         )
         self.resource_type = kwargs.get("resource_type", NodeType.Model)
         self.group = kwargs.get("group")
         self.event_time = kwargs.get("config", {}).get("event_time", None)
+        self.contract_info = kwargs.get("contract", {}) or {}
+        self.columns_info = kwargs.get("columns", {}) or {}
 
     @property
     def unique_id(self) -> str:

--- a/dbt_loom/__init__.py
+++ b/dbt_loom/__init__.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, fields as dataclass_fields
 import os
 import re
 from pathlib import Path
@@ -25,6 +25,28 @@ from dbt_loom.logging import fire_event
 from dbt_loom.manifests import ManifestLoader, ManifestNode
 
 import importlib.metadata
+
+
+def _build_column_info(columns_data: dict) -> dict:
+    """Build ColumnInfo objects from raw manifest column data, with dbt version compatibility."""
+    try:
+        from dbt.artifacts.resources.v1.components import ColumnInfo
+    except ImportError:
+        try:
+            from dbt.contracts.graph.nodes import ColumnInfo  # type: ignore
+        except ImportError:
+            return {}
+
+    known_fields = {f.name for f in dataclass_fields(ColumnInfo)}
+    result = {}
+    for col_name, col_data in columns_data.items():
+        try:
+            result[col_name] = ColumnInfo(
+                **{k: v for k, v in col_data.items() if k in known_fields}
+            )
+        except Exception:
+            pass
+    return result
 
 
 @dataclass
@@ -219,6 +241,12 @@ class dbtLoom(dbtPlugin):
             model = function(args)
             model.group = args.group
             model.config.event_time = args.event_time
+
+            if args.contract_info.get("enforced"):
+                model.contract.enforced = True
+                if args.columns_info:
+                    model.columns = _build_column_info(args.columns_info)
+
             return model
 
         return outer_function

--- a/dbt_loom/__init__.py
+++ b/dbt_loom/__init__.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass, fields as dataclass_fields
+from dataclasses import dataclass
 import os
 import re
 from pathlib import Path
@@ -37,13 +37,10 @@ def _build_column_info(columns_data: dict) -> dict:
         except ImportError:
             return {}
 
-    known_fields = {f.name for f in dataclass_fields(ColumnInfo)}
     result = {}
     for col_name, col_data in columns_data.items():
         try:
-            result[col_name] = ColumnInfo(
-                **{k: v for k, v in col_data.items() if k in known_fields}
-            )
+            result[col_name] = ColumnInfo.from_dict(col_data)
         except Exception:
             pass
     return result
@@ -244,6 +241,9 @@ class dbtLoom(dbtPlugin):
 
             if args.contract_info.get("enforced"):
                 model.contract.enforced = True
+                model.contract.alias_types = args.contract_info.get("alias_types", True)
+                model.contract.checksum = args.contract_info.get("checksum")
+                model.config.contract.enforced = True
                 if args.columns_info:
                     model.columns = _build_column_info(args.columns_info)
 

--- a/dbt_loom/manifests.py
+++ b/dbt_loom/manifests.py
@@ -67,6 +67,7 @@ class ManifestNode(BaseModel, use_enum_values=True):
     enabled: bool = True
     config: dict = Field(default_factory=dict)
     contract: dict = Field(default_factory=dict)
+    columns: dict = Field(default_factory=dict)
 
     @validator("depends_on_nodes", always=True)
     def default_depends_on_nodes(cls, v, values):

--- a/dbt_loom/manifests.py
+++ b/dbt_loom/manifests.py
@@ -66,6 +66,7 @@ class ManifestNode(BaseModel, use_enum_values=True):
     depends_on_nodes: List[str] = Field(default_factory=list)
     enabled: bool = True
     config: dict = Field(default_factory=dict)
+    contract: dict = Field(default_factory=dict)
 
     @validator("depends_on_nodes", always=True)
     def default_depends_on_nodes(cls, v, values):


### PR DESCRIPTION
Summary

- Add contract and columns fields to ManifestNode to preserve contract/column info from upstream project manifests
- Store contract_info and columns_info in LoomModelNodeArgs as separate attributes — same pattern as existing group and event_time fields, since ModelNodeArgs doesn't accept them directly
- Inject into ModelNode via model_node_wrapper — only when contract.enforced == true, sets model.contract, model.config.contract, and model.columns
- Use ColumnInfo.from_dict() for deserialization — delegates ColumnConfig and ConstraintType type conversion to dbt's mashumaro-based codec instead of doing it manually

Why

dbt contracts are meant to guarantee schema stability for downstream consumers, but the contract and column information was previously lost at project boundaries. This change allows project B to see the enforced contract and column type definitions from project A's models, enabling accurate cross-project lineage and dbt docs visibility.

Scope

Only applies to models with contract.enforced = true. Models without an enforced contract behave exactly as before.